### PR TITLE
Updated JENKINS_USER AND JENKINS_GROUP to use values set in attribute…

### DIFF
--- a/templates/default/jenkins-config-debian.erb
+++ b/templates/default/jenkins-config-debian.erb
@@ -18,8 +18,8 @@ JAVA_ARGS="<%= node['jenkins']['master']['jvm_options'] %>"
 PIDFILE=/var/run/jenkins/jenkins.pid
 
 # user and group to be invoked as (default to jenkins)
-JENKINS_USER=jenkins
-JENKINS_GROUP=jenkins
+JENKINS_USER=<%= node['jenkins']['master']['user'] %>
+JENKINS_GROUP=<%= node['jenkins']['master']['group'] %>
 
 # location of the jenkins war file
 JENKINS_WAR=/usr/share/jenkins/jenkins.war


### PR DESCRIPTION
Hardcoded values in jenkins-config-debian.erb for JENKINS_USER and JENKINS_GROUP prevent installation if they are changed from the defaults.

This pull request updates the jenkins-config-debian.erb template to set JENKINS_USER and JENKINS_GROUP from attribute values.