### PR TITLE
Support for secret text credentials

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -125,6 +125,38 @@ EOH
     end
 
     #
+    # A Groovy snippet that will set the requested local Groovy variable
+    # to an instance of the credentials represented by `secret`.
+    # Returns the Groovy `null` if no credentials are found.
+    #
+    # @param [String] secret
+    # @param [String] description
+    # @param [String] groovy_variable_name
+    # @return [String]
+    #
+    def credentials_for_secret_groovy(secret, description, groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+        import jenkins.model.Jenkins;
+        import hudson.util.Secret;
+        import com.cloudbees.plugins.credentials.CredentialsProvider
+        import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+        import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+        available_credentials =
+          CredentialsProvider.lookupCredentials(
+            StringCredentials.class,
+            Jenkins.getInstance(),
+            hudson.security.ACL.SYSTEM
+          ).findAll({
+            it.secret      == new Secret(#{ convert_to_groovy(secret) }) &&
+            it.description == #{ convert_to_groovy(description) }
+          })
+
+        #{groovy_variable_name} = available_credentials.size() > 0 ? available_credentials[0] : null
+      EOH
+    end
+
+    #
     # Helper method for converting a Ruby value to it's equivalent in
     # Groovy.
     #

--- a/libraries/credentials.rb
+++ b/libraries/credentials.rb
@@ -25,10 +25,8 @@ require_relative '_params_validate'
 class Chef
   class Resource::JenkinsCredentials < Resource::LWRPBase
     require 'securerandom'
-    include Jenkins::Helper
 
     # Chef attributes
-    identity_attr :username
     provides :jenkins_credentials
 
     # Set the resource name
@@ -46,15 +44,9 @@ class Chef
     default_action :create
 
     # Attributes
-    attribute :username,
-              kind_of: String,
-              name_attribute: true
     attribute :id,
               kind_of: String,
               default: lazy { SecureRandom.uuid }
-    attribute :description,
-              kind_of: String,
-              default: lazy { |new_resource| "Credentials for #{new_resource.username} - created by Chef" }
 
     attr_writer :exists
 
@@ -84,7 +76,6 @@ class Chef
         @current_resource.exists = true
         @current_resource.id(current_credentials[:id])
         @current_resource.description(current_credentials[:description])
-        @current_resource.username(current_credentials[:username])
       end
 
       @current_resource
@@ -116,8 +107,7 @@ class Chef
 
             #{credentials_groovy}
 
-            // Create or update the credentials in the Jenkins instance
-            #{credentials_for_username_groovy(new_resource.username, 'existing_credentials')}
+            #{fetch_existing_credentials_groovy('existing_credentials')}
 
             if(existing_credentials != null) {
               credentials_store.updateCredentials(
@@ -149,7 +139,7 @@ class Chef
                 'com.cloudbees.plugins.credentials.SystemCredentialsProvider'
               )[0].getStore()
 
-            #{credentials_for_username_groovy(new_resource.username, 'existing_credentials')}
+            #{fetch_existing_credentials_groovy('existing_credentials')}
 
             if(existing_credentials != null) {
               credentials_store.removeCredentials(
@@ -176,6 +166,38 @@ class Chef
     #
     def credentials_groovy
       fail NotImplementedError, 'You must implement #credentials_groovy.'
+    end
+
+    #
+    # Returns a Groovy snippet that fetches credentials from the
+    # credentials store. The snippet relies on the existence of both
+    # 'credentials_store' and 'credentials' variables, representing the
+    # Jenkins credentials store and the credentials to be fetched, respectively
+    # @abstract
+    # @return [String]
+    #
+    def fetch_existing_credentials_groovy(groovy_variable_name)
+      fail NotImplementedError, 'You must implement #fetch_existing_credentials_groovy.'
+    end
+
+    #
+    # Returns a Groovy snippet with an array of the resource attributes. The snippet
+    # relies on the existence of a variable credentials that represents the resource
+    # @abstract
+    # @return [String]
+    #
+    def resource_attributes_groovy(groovy_variable_name)
+      fail NotImplementedError, 'You must implement #resource_attributes_groovy.'
+    end
+
+    #
+    # Helper method for determining if the given JSON is in sync with the
+    # current configuration on the Jenkins instance.
+    #
+    # @return [Boolean]
+    #
+    def correct_config?
+      fail NotImplementedError, 'You must implement #correct_config?.'
     end
 
     #
@@ -210,17 +232,13 @@ class Chef
         import com.cloudbees.plugins.credentials.impl.*;
         import com.cloudbees.jenkins.plugins.sshcredentials.impl.*;
 
-        #{credentials_for_username_groovy(new_resource.username, 'credentials')}
+        #{fetch_existing_credentials_groovy('credentials')}
 
         if(credentials == null) {
           return null
         }
 
-        current_credentials = [
-          id:credentials.id,
-          description:credentials.description,
-          username:credentials.username
-        ]
+        #{resource_attributes_groovy('current_credentials')}
 
         #{credentials_attributes.join("\n")}
 
@@ -235,26 +253,6 @@ class Chef
       # Values that were serialized as nil/null are deserialized as an
       # empty string! :( Let's ensure we convert back to nil.
       @current_credentials = convert_blank_values_to_nil(@current_credentials)
-    end
-
-    #
-    # Helper method for determining if the given JSON is in sync with the
-    # current configuration on the Jenkins instance.
-    #
-    # @return [Boolean]
-    #
-    def correct_config?
-      wanted_credentials = {
-        description: new_resource.description,
-        username: new_resource.username,
-      }
-
-      attribute_to_property_map.keys.each do |key|
-        wanted_credentials[key] = new_resource.send(key)
-      end
-
-      # Don't compare the ID as it is generated
-      current_credentials.dup.tap { |c| c.delete(:id) } == convert_blank_values_to_nil(wanted_credentials)
     end
   end
 end

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -20,10 +20,11 @@
 #
 
 require_relative 'credentials'
+require_relative 'credentials_user'
 require_relative '_params_validate'
 
 class Chef
-  class Resource::JenkinsPasswordCredentials < Resource::JenkinsCredentials
+  class Resource::JenkinsPasswordCredentials < Resource::JenkinsCredentialsUser
     # Chef attributes
     provides :jenkins_password_credentials
 
@@ -42,7 +43,7 @@ class Chef
 end
 
 class Chef
-  class Provider::JenkinsPasswordCredentials < Provider::JenkinsCredentials
+  class Provider::JenkinsPasswordCredentials < Provider::JenkinsCredentialsUser
     def load_current_resource
       @current_resource ||= Resource::JenkinsPasswordCredentials.new(new_resource.name)
 

--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -20,10 +20,11 @@
 #
 
 require_relative 'credentials'
+require_relative 'credentials_user'
 require_relative '_params_validate'
 
 class Chef
-  class Resource::JenkinsPrivateKeyCredentials < Resource::JenkinsCredentials
+  class Resource::JenkinsPrivateKeyCredentials < Resource::JenkinsCredentialsUser
     require 'openssl'
 
     # Chef attributes
@@ -66,7 +67,7 @@ class Chef
 end
 
 class Chef
-  class Provider::JenkinsPrivateKeyCredentials < Provider::JenkinsCredentials
+  class Provider::JenkinsPrivateKeyCredentials < Provider::JenkinsCredentialsUser
     def load_current_resource
       @current_resource ||= Resource::JenkinsPrivateKeyCredentials.new(new_resource.name)
 

--- a/libraries/credentials_secret_text.rb
+++ b/libraries/credentials_secret_text.rb
@@ -1,0 +1,136 @@
+#
+# Cookbook Name:: jenkins
+# HWRP:: credentials_secret_text
+#
+# Author:: Miguel Ferreira <mferreira@schubergphilis.com>
+#
+# Copyright 2015, Schuberg Philis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative 'credentials'
+require_relative '_params_validate'
+
+class Chef
+  class Resource::JenkinsSecretTextCredentials < Resource::JenkinsCredentials
+    # Chef attributes
+    identity_attr :description
+    provides :jenkins_secret_text_credentials
+
+    # Set the resource name
+    self.resource_name = :jenkins_secret_text_credentials
+
+    # Actions
+    actions :create, :delete
+    default_action :create
+
+    # Attributes
+    attribute :description,
+              kind_of: String,
+              name_attribute: true
+    attribute :secret,
+              kind_of: String,
+              required: true
+  end
+end
+
+class Chef
+  class Provider::JenkinsSecretTextCredentials < Provider::JenkinsCredentials
+    def load_current_resource
+      @current_resource ||= Resource::JenkinsSecretTextCredentials.new(new_resource.name)
+
+      super
+
+      if current_credentials
+        @current_resource.secret(current_credentials[:secret])
+      end
+
+      @current_credentials
+    end
+
+    protected
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#credentials_groovy
+    # @see https://github.com/jenkinsci/plain-credentials-plugin/blob/master/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/StringCredentialsImpl.java
+    #
+    def credentials_groovy
+      <<-EOH.gsub(/ ^{8}/, '')
+        import hudson.util.Secret;
+        import com.cloudbees.plugins.credentials.CredentialsScope;
+        import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+
+        credentials = new StringCredentialsImpl(
+          CredentialsScope.GLOBAL,
+          #{ convert_to_groovy(new_resource.id) },
+          #{ convert_to_groovy(new_resource.description) },
+          new Secret(#{ convert_to_groovy(new_resource.secret) })
+        )
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#fetch_credentials_groovy
+    #
+    def fetch_existing_credentials_groovy(groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+        #{ credentials_for_secret_groovy(new_resource.secret, new_resource.description, groovy_variable_name) }
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#resource_attributes_groovy
+    #
+    def resource_attributes_groovy(groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+        #{groovy_variable_name} = [
+          id:credentials.id,
+          description:credentials.description,
+          secret:credentials.secret
+        ]
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#attribute_to_property_map
+    #
+    def attribute_to_property_map
+      {
+        secret: 'credentials.secret.plainText',
+      }
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#correct_config?
+    #
+    def correct_config?
+      wanted_credentials = {
+        description: new_resource.description,
+        secret: new_resource.secret,
+      }
+
+      attribute_to_property_map.keys.each do |key|
+        wanted_credentials[key] = new_resource.send(key)
+      end
+
+      # Don't compare the ID as it is generated
+      current_credentials.dup.tap { |c| c.delete(:id) } == convert_blank_values_to_nil(wanted_credentials)
+    end
+  end
+end
+
+Chef::Platform.set(
+  resource: :jenkins_secret_text_credentials,
+  provider: Chef::Provider::JenkinsSecretTextCredentials,
+)

--- a/libraries/credentials_user.rb
+++ b/libraries/credentials_user.rb
@@ -1,0 +1,97 @@
+#
+# Cookbook Name:: jenkins
+# HWRP:: credentials_user
+#
+# Author:: Miguel Ferreira <mferreira@schubergphilis.com>
+#
+# Copyright 2015, Schuberg Philis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  class Resource::JenkinsCredentialsUser < Resource::JenkinsCredentials
+    require 'securerandom'
+    include Jenkins::Helper
+
+    # Chef attributes
+    identity_attr :username
+
+    # Attributes
+    attribute :username,
+              kind_of: String,
+              name_attribute: true
+    attribute :description,
+              kind_of: String,
+              default: lazy { |new_resource| "Credentials for #{new_resource.username} - created by Chef" }
+  end
+end
+
+class Chef
+  class Provider::JenkinsCredentialsUser < Provider::JenkinsCredentials
+    include Jenkins::Helper
+
+    def load_current_resource
+      @current_resource ||= Resource::JenkinsCredentialsUser.new(new_resource.name)
+
+      super
+
+      if current_credentials
+        @current_resource.username(current_credentials[:username])
+      end
+
+      @current_resource
+    end
+
+    protected
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#save_credentials_groovy
+    #
+    def fetch_existing_credentials_groovy(groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+        #{credentials_for_username_groovy(new_resource.username, groovy_variable_name)}
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#resource_attributes_groovy
+    #
+    def resource_attributes_groovy(groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+        #{groovy_variable_name} = [
+          id:credentials.id,
+          description:credentials.description,
+          username:credentials.username
+        ]
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#correct_config?
+    #
+    def correct_config?
+      wanted_credentials = {
+        description: new_resource.description,
+        username: new_resource.username,
+      }
+
+      attribute_to_property_map.keys.each do |key|
+        wanted_credentials[key] = new_resource.send(key)
+      end
+
+      # Don't compare the ID as it is generated
+      current_credentials.dup.tap { |c| c.delete(:id) } == convert_blank_values_to_nil(wanted_credentials)
+    end
+  end
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -48,6 +48,20 @@ if defined?(ChefSpec)
       resource_name)
   end
 
+  def create_jenkins_secret_text_credentials(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+      :jenkins_secret_text_credentials,
+      :create,
+      resource_name)
+  end
+
+  def delete_jenkins_secret_text_credentials(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+      :jenkins_secret_text_credentials,
+      :delete,
+      resource_name)
+  end
+
   def create_jenkins_job(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(
       :jenkins_job,

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
@@ -43,3 +43,15 @@ end
 jenkins_password_credentials 'dollarbills' do
   password '$uper$ecret'
 end
+
+# Plugin required for Secret Text credentials
+jenkins_plugin 'plain-credentials' do
+  install_deps true
+  notifies :restart, 'service[jenkins]',       :immediately
+  notifies :restart, 'runit_service[jenkins]', :immediately
+end
+
+# Test creating a secret text with a dollar sign in it
+jenkins_secret_text_credentials 'dollarbills_secret' do
+  secret '$uper$ecret'
+end

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/delete.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/delete.rb
@@ -30,3 +30,7 @@ end
 jenkins_private_key_credentials 'jenkins3' do
   action :delete
 end
+
+jenkins_secret_text_credentials 'dollarbills_secret' do
+  action :delete
+end

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/delete.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/delete.rb
@@ -4,7 +4,7 @@ include_recipe 'jenkins::master'
 include_recipe 'jenkins_credentials::create'
 
 # test deletion with base resource
-jenkins_credentials 'schisamo' do
+jenkins_password_credentials 'schisamo' do
   action :delete
 end
 
@@ -18,7 +18,7 @@ jenkins_password_credentials 'schisamo3' do
 end
 
 # test deletion with base resource
-jenkins_credentials 'jenkins2' do
+jenkins_private_key_credentials 'jenkins2' do
   action :delete
 end
 

--- a/test/integration/jenkins_credentials_create/serverspec/assert_created_spec.rb
+++ b/test/integration/jenkins_credentials_create/serverspec/assert_created_spec.rb
@@ -41,3 +41,8 @@ describe jenkins_user_credentials('dollarbills') do
   it { should be_a_jenkins_credentials }
   it { should have_password('$uper$ecret') }
 end
+
+describe jenkins_secret_text_credentials('dollarbills_secret') do
+  it { should be_a_jenkins_credentials }
+  it { should have_secret('$uper$ecret') }
+end

--- a/test/integration/jenkins_credentials_create/serverspec/assert_created_spec.rb
+++ b/test/integration/jenkins_credentials_create/serverspec/assert_created_spec.rb
@@ -1,43 +1,43 @@
 require_relative '../../../kitchen/data/spec_helper'
 
-describe jenkins_credentials('schisamo') do
+describe jenkins_user_credentials('schisamo') do
   it { should be_a_jenkins_credentials }
   it { should have_description('passwords are for suckers') }
   it { should have_password('superseekret') }
 end
 
-describe jenkins_credentials('schisamo2') do
+describe jenkins_user_credentials('schisamo2') do
   it { should be_a_jenkins_credentials }
   it { should have_id('63e11302-d446-4ba0-8aa4-f5821f74d36f') }
   it { should have_password('superseekret') }
 end
 
-describe jenkins_credentials('schisamo3') do
+describe jenkins_user_credentials('schisamo3') do
   it { should be_a_jenkins_credentials }
   it { should have_id('schisamo3') }
   it { should have_password('superseekret') }
 end
 
-describe jenkins_credentials('jenkins') do
+describe jenkins_user_credentials('jenkins') do
   it { should be_a_jenkins_credentials }
   it { should have_description('this is more like it') }
   it { should have_private_key(File.read(File.expand_path('../../../../kitchen/data/data/test_id_rsa', __FILE__))) }
 end
 
-describe jenkins_credentials('jenkins2') do
+describe jenkins_user_credentials('jenkins2') do
   it { should be_a_jenkins_credentials }
   it { should have_private_key(File.read(File.expand_path('../../../../kitchen/data/data/test_id_rsa_with_passphrase', __FILE__)), 'secret') }
   it { should have_passphrase('secret') }
 end
 
-describe jenkins_credentials('jenkins3') do
+describe jenkins_user_credentials('jenkins3') do
   it { should be_a_jenkins_credentials }
   it { should have_description('I specified an ID') }
   it { should have_id('766952b8-e1ea-4ee1-b769-e159681cb893') }
   it { should have_private_key(File.read(File.expand_path('../../../../kitchen/data/data/test_id_rsa', __FILE__))) }
 end
 
-describe jenkins_credentials('dollarbills') do
+describe jenkins_user_credentials('dollarbills') do
   it { should be_a_jenkins_credentials }
   it { should have_password('$uper$ecret') }
 end

--- a/test/integration/jenkins_credentials_delete/serverspec/assert_deleted_spec.rb
+++ b/test/integration/jenkins_credentials_delete/serverspec/assert_deleted_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../kitchen/data/spec_helper'
 
-%w(schisamo schisamo2 schisamo3 jenkins jenkins2 jenkins3).each do |username|
-  describe jenkins_credentials(username) do
+%w(schisamo schisamo2 schisamo3 jenkins jenkins2 jenkins3 dollarbills_secret).each do |name|
+  describe jenkins_user_credentials(name) do
     it { should_not be_a_jenkins_credentials }
   end
 end

--- a/test/shared/support/dsl.rb
+++ b/test/shared/support/dsl.rb
@@ -2,8 +2,8 @@ module RSpec
   module Core
     #
     module DSL
-      def jenkins_credentials(username)
-        Serverspec::Type::JenkinsCredentials.new(username)
+      def jenkins_user_credentials(username)
+        Serverspec::Type::JenkinsUserCredentials.new(username)
       end
 
       def jenkins_job(name)

--- a/test/shared/support/dsl.rb
+++ b/test/shared/support/dsl.rb
@@ -6,6 +6,10 @@ module RSpec
         Serverspec::Type::JenkinsUserCredentials.new(username)
       end
 
+      def jenkins_secret_text_credentials(description)
+        Serverspec::Type::JenkinsSecretTextCredentials.new(description)
+      end
+
       def jenkins_job(name)
         Serverspec::Type::JenkinsJob.new(name)
       end

--- a/test/shared/support/jenkins_credentials.rb
+++ b/test/shared/support/jenkins_credentials.rb
@@ -23,6 +23,23 @@ module Serverspec
         id === try { xml.elements['id'].text }
       end
 
+      private
+
+      def try(&block)
+        block.call
+      rescue NoMethodError
+        nil
+      end
+    end
+
+    class JenkinsUserCredentials < JenkinsCredentials
+      attr_reader :username
+
+      def initialize(username)
+        @username = username
+        super
+      end
+
       def has_description?(description)
         description === try { xml.elements['description'].text }
       end
@@ -58,11 +75,8 @@ module Serverspec
       rescue Errno::ENOENT
         @xml = nil
       end
+    end
 
-      def try(&block)
-        block.call
-      rescue NoMethodError
-        nil
       end
     end
   end

--- a/test/shared/support/jenkins_credentials.rb
+++ b/test/shared/support/jenkins_credentials.rb
@@ -77,6 +77,29 @@ module Serverspec
       end
     end
 
+    class JenkinsSecretTextCredentials < JenkinsCredentials
+      attr_reader :description
+
+      def initialize(description)
+        @description = description
+        super
+      end
+
+      # TODO: encrypt provided secret and compare to Jenkins value
+      def has_secret?(_secret)
+        !(try { xml.elements['secret'].text }).nil?
+      end
+
+      private
+
+      def xml
+        return @xml if @xml
+
+        contents = ::File.read('/var/lib/jenkins/credentials.xml')
+        doc = REXML::Document.new(contents)
+        @xml = REXML::XPath.first(doc, "//*[description/text() = '#{description}']/")
+      rescue Errno::ENOENT
+        @xml = nil
       end
     end
   end


### PR DESCRIPTION
With the plain-credentials plugin, it is possible to define secret text credentials. These are credentials that only hold a string. This PR adds support for those types of credentials.

Since the cookbook already supported user-related credentials, I've refactored the user specific code from the existing providers into an intermediate class (JenkinsCredentialsUser) that becomes the base class for both the password and private key credentials providers. I've adapted the respective ServerSpec provider as well.
To add the new type of credentials I've added a new class (JenkinsSecretTextCredentials) and a library helper method. I've also added to the ChefSpec matchers, ServerSpec matchers and tests. In order to test the creation of a secret text credentials with kitchen, I've had to modify the `jenkins_credentials::create` recipe to first install the plain-credentials plugin (and restart the jenkins service) before calling the new provider. I didn't think of a way to detect of the plugin is installed before trying to create a secret text credential.

I've ran the following tests:
```
kitchen converge jenkins-credentials-create-ubuntu-1204 && kitchen verify jenkins-credentials-create-ubuntu-1204
kitchen converge jenkins-credentials-create-ubuntu-1204 && kitchen verify jenkins-credentials-create-ubuntu-1204

kitchen converge jenkins-credentials-create-centos-66 && kitchen verify jenkins-credentials-create-centos-66
kitchen converge jenkins-credentials-create-centos-66 && kitchen verify jenkins-credentials-create-centos-66

kitchen test jenkins-credentials-delete-ubuntu-1204
kitchen test jenkins-credentials-delete-centos-66
```

I've converged and verified twice the creation of the credentials to test that the current resource was being well identified.