### PR TITLE
fix path to jar cache for windows slave

### DIFF
--- a/templates/default/jenkins-slave.bat.erb
+++ b/templates/default/jenkins-slave.bat.erb
@@ -1,4 +1,4 @@
 <% for @arg in @pre_run_cmds -%>
   <%= @arg %>
 <% end -%>
-"<%= @java_bin %>" -Xrs <%= @new_resource.jvm_options %> -jar "<%= @slave_jar %>" -jnlpUrl <%= @jnlp_url %> <%= @jnlp_secret.nil? ? '' : "-secret #{@jnlp_secret}" %>
+"<%= @java_bin %>" -Xrs <%= @new_resource.jvm_options %> -jar "<%= @slave_jar %>" -jnlpUrl <%= @jnlp_url %> <%= @jnlp_secret.nil? ? '' : "-secret #{@jnlp_secret}" %> -jar-cache <%= @new_resource.remote_fs %>\cache


### PR DESCRIPTION
Windows slave tends to store jar cache in administrator users home directory while being run as another user.
This fix specifies correct path in a bat file using existing attributes.