### PR TITLE
Change remote directory resource to work with domain users

### DIFF
--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -110,7 +110,11 @@ class Chef
       return @remote_fs_dir_resource if @remote_fs_dir_resource
       @remote_fs_dir_resource = Chef::Resource::Directory.new(new_resource.remote_fs, run_context)
       user_parts = user_hash
-      @remote_fs_dir_resource.rights(:full_control, user_parts['username'])
+      if (user_parts['domain'] == '.')
+        @remote_fs_dir_resource.rights(:full_control, user_parts['username'])
+      else
+        @remote_fs_dir_resource.rights(:full_control, new_resource.user)
+      end
       @remote_fs_dir_resource.recursive(true)
       @remote_fs_dir_resource
     end


### PR DESCRIPTION
Without this correction, I couldn't make the jenkins_windows_slave work when using a trusted domain account for the service.