### PR TITLE
Changes endpoint for 'wait_until_ready'

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -390,7 +390,7 @@ EOH
     def wait_until_ready!
       Timeout.timeout(timeout, JenkinsTimeout) do
         begin
-          open(endpoint)
+          open("#{endpoint}/whoAmI/")
         rescue SocketError,
                Errno::ECONNREFUSED,
                Errno::ECONNRESET,


### PR DESCRIPTION
This allows the ready check (to see if Jenkins is ready after a restart)
to work even if "HTTP Header by reverse proxy" Security Realm is enabled
(which expects a "Header User Name" to be set) by polling an
"Unprotected URL" (built-in URLs that are excluded from authentication)