### PR TITLE
Download plugin into the cache only if it's missing

### DIFF
--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -307,7 +307,7 @@ EOH
       plugin = Chef::Resource::RemoteFile.new(path, run_context)
       plugin.source(source_url)
       plugin.backup(false)
-      plugin.run_action(:create)
+      plugin.run_action(:create_if_missing)
 
       # Install the plugin from our local cache on disk. There is a bug in
       # Jenkins that prevents Jenkins from following 302 redirects, so we


### PR DESCRIPTION
The plugins needs to be downloaded only if it has not already been downloaded into Chef's cache.  We need this option, since we sometimes perform installations where there is no Internet connection.