### PR TITLE
allow overriding of the runit process state

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -193,6 +193,20 @@ default['jenkins']['master'].tap do |master|
   master['runit']['sv_timeout'] = 7
 
   #
+  # Override the default Runit user to start the jenkins service with.
+  #
+  #   node.set['jenkins']['master']['runit']['user'] = 'jenkins:rvm'
+  #
+  master['runit']['user'] = master['user']
+
+  #
+  # Override the default Runit group to start the jenkins service with.
+  #
+  #   node.set['jenkins']['master']['runit']['group'] = 'jenkins:jenkins:rvm'
+  #
+  master['runit']['group'] = master['group']
+
+  #
   # Repository URL. Default is latest
   #
   master['repository'] = case node['platform_family']

--- a/templates/default/sv-jenkins-run.erb
+++ b/templates/default/sv-jenkins-run.erb
@@ -9,7 +9,7 @@
 exec 2>&1
 cd <%= node['jenkins']['master']['home'] %>
 touch jenkins.start
-exec chpst -u <%= node['jenkins']['master']['user'] %> -U <%= node['jenkins']['master']['user'] %> \
+exec chpst -u <%= node['jenkins']['master']['runit']['user'] %> -U <%= node['jenkins']['master']['runit']['group'] %> \
   env HOME=<%= node['jenkins']['master']['home'] %> \
   JENKINS_HOME=<%= node['jenkins']['master']['home'] %> \
   <%= node['jenkins']['java'] %> <%= node['jenkins']['master']['jvm_options'] %> -jar jenkins.war \


### PR DESCRIPTION
This commit will allow the definition of the user(s) and group(s) for the jenkins runit process. 
This is very helpful in order to manage Ruby versions installed via RVM.

```
runit: {
  sv_timeout: 240,
  user: 'jenkins:rvm',
  group: 'jenkins:jenkins:rvm'
}
```
