### PR TITLE
correct documentation on checksum

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -76,7 +76,7 @@ default['jenkins']['master'].tap do |master|
   # The checksum of the war file. This is use to verify that the remote war file
   # has not been tampered with (such as a MITM attack). If you leave this #
   # attribute set to +nil+, no validation will be performed. If this attribute
-  # is set to the wrong MD5 checksum, the Chef Client run will fail.
+  # is set to the wrong SHA-256 checksum, the Chef Client run will fail.
   #
   #   node.set['jenkins']['master']['checksum'] = 'abcd1234...'
   #


### PR DESCRIPTION
### Description
Documentation indicates the remote_file checksum is an MD5, it is in fact a SHA-256 (https://docs.chef.io/resource_remote_file.html)

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD (Should not affect tests)
- [x] New functionality includes testing. (N/A)
- [x] New functionality has been documented in the README if applicable (N/A)
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD