### PR TITLE
Add option to set MaxHeapSize for executor,default -Xmx256M

### DIFF
--- a/attributes/executor.rb
+++ b/attributes/executor.rb
@@ -44,4 +44,10 @@ default['jenkins']['executor'].tap do |executor|
   # Please see the +Proxies+ section of the README for more information.
   #
   executor['proxy'] = nil
+
+  #
+  # On Windows systems with 64GB+ RAM, the MaxHeapSize of 256 may not be enough,
+  # this allows you to set a different value for MaxHeapSize on the executor.
+  #
+  executor['mx'] = 256
 end

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -45,6 +45,8 @@ module Jenkins
     #   +/usr/share/jenkins/cli/java/cli.jar+)
     # @option options [String] :java
     #   the full path to the java executable on the system (default: +java+)
+    # @option options [String] :mx
+    #   the MaxHeapSize for the executor (default: -Xmx256M)
     #
     # @return [Jenkins::Executor]
     #
@@ -70,6 +72,7 @@ module Jenkins
       command_options = pieces.last.is_a?(Hash) ? pieces.pop : {}
       command = []
       command << %("#{options[:java]}")
+      command << %(-Xmx#{options[:mx]}M) if options[:mx]
       command << %(-jar "#{options[:cli]}")
       command << %(-s #{URI.escape(options[:endpoint])}) if options[:endpoint]
       command << %(-i "#{options[:key]}")                if options[:key]

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -69,6 +69,7 @@ EOH
         h[:proxy]    = proxy if proxy_given?
         h[:endpoint] = endpoint
         h[:timeout]  = timeout if timeout_given?
+        h[:mx]       = mx if mx_given?
         h[:username] = username unless username.nil?
         h[:password] = password unless password.nil?
       end
@@ -318,6 +319,24 @@ EOH
     #
     def timeout_given?
       !node['jenkins']['executor']['timeout'].nil?
+    end
+
+    #
+    # The global MaxHeapSize for the executor.
+    #
+    # @return [Fixnum]
+    #
+    def mx
+      node['jenkins']['executor']['mx']
+    end
+
+    #
+    # Boolean method to determine if MaxHeapSize was supplied.
+    #
+    # @return [Boolean]
+    #
+    def mx_given?
+      !node['jenkins']['executor']['mx'].nil?
     end
 
     # Username used when invoking cli

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -9,9 +9,10 @@ describe Jenkins::Executor do
     end
 
     it 'overrides with options from the initializer' do
-      options = described_class.new(cli: 'foo', java: 'bar').options
+      options = described_class.new(cli: 'foo', java: 'bar', mx: 512).options
       expect(options[:cli]).to eq('foo')
       expect(options[:java]).to eq('bar')
+      expect(options[:mx]).to eq(512)
     end
   end
 
@@ -62,6 +63,15 @@ describe Jenkins::Executor do
       it 'adds --password option' do
         subject.options[:password] = 'password'
         command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --password "password")
+        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
+        subject.execute!('foo')
+      end
+    end
+
+    context 'when a :mx option is given' do
+      it 'adds -xMXxxxM option' do
+        subject.options[:mx] = 512
+        command = %("java" -Xmx512M -jar "/usr/share/jenkins/cli/java/cli.jar" foo)
         expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
         subject.execute!('foo')
       end


### PR DESCRIPTION
### Description
Allows to set MaxHeapSize on executor.

### Issues Resolved

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


