### PR TITLE
[GH-426] - Chef 11 backward compatibility

### DIFF
--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -44,7 +44,7 @@ class Chef
   class Provider::JenkinsCommand < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides :jenkins_command
+    provides (:jenkins_command) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsCommand.new(new_resource.command)

--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -44,7 +44,7 @@ class Chef
   class Provider::JenkinsCommand < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides (:jenkins_command) if defined?(provides)
+    provides :jenkins_command if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsCommand.new(new_resource.command)

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -39,7 +39,7 @@ end
 
 class Chef
   class Provider::JenkinsPasswordCredentials < Provider::JenkinsUserCredentials
-    provides :jenkins_password_credentials
+    provides (:jenkins_password_credentials) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsPasswordCredentials.new(new_resource.name)

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -39,7 +39,7 @@ end
 
 class Chef
   class Provider::JenkinsPasswordCredentials < Provider::JenkinsUserCredentials
-    provides (:jenkins_password_credentials) if defined?(provides)
+    provides :jenkins_password_credentials if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsPasswordCredentials.new(new_resource.name)

--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -62,7 +62,7 @@ end
 
 class Chef
   class Provider::JenkinsPrivateKeyCredentials < Provider::JenkinsUserCredentials
-    provides :jenkins_private_key_credentials
+    provides (:jenkins_private_key_credentials) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsPrivateKeyCredentials.new(new_resource.name)

--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -62,7 +62,7 @@ end
 
 class Chef
   class Provider::JenkinsPrivateKeyCredentials < Provider::JenkinsUserCredentials
-    provides (:jenkins_private_key_credentials) if defined?(provides)
+    provides :jenkins_private_key_credentials if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsPrivateKeyCredentials.new(new_resource.name)

--- a/libraries/credentials_secret_text.rb
+++ b/libraries/credentials_secret_text.rb
@@ -41,7 +41,7 @@ end
 
 class Chef
   class Provider::JenkinsSecretTextCredentials < Provider::JenkinsCredentials
-    provides :jenkins_secret_text_credentials
+    provides (:jenkins_secret_text_credentials) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsSecretTextCredentials.new(new_resource.name)

--- a/libraries/credentials_secret_text.rb
+++ b/libraries/credentials_secret_text.rb
@@ -41,7 +41,7 @@ end
 
 class Chef
   class Provider::JenkinsSecretTextCredentials < Provider::JenkinsCredentials
-    provides (:jenkins_secret_text_credentials) if defined?(provides)
+    provides :jenkins_secret_text_credentials if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsSecretTextCredentials.new(new_resource.name)

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -81,7 +81,7 @@ class Chef
   class Provider::JenkinsJob < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides :jenkins_job
+    provides (:jenkins_job) if defined?(provides)
 
     # After some careful discussions internally, it was decided that
     # raising an exception when the job does not exist is the best

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -81,7 +81,7 @@ class Chef
   class Provider::JenkinsJob < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides (:jenkins_job) if defined?(provides)
+    provides :jenkins_job if defined?(provides)
 
     # After some careful discussions internally, it was decided that
     # raising an exception when the job does not exist is the best

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -69,7 +69,7 @@ class Chef
   class Provider::JenkinsPlugin < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides (:jenkins_plugin) if defined?(provides)
+    provides :jenkins_plugin if defined?(provides)
 
     class PluginNotInstalled < StandardError
       def initialize(plugin, action)

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -69,7 +69,7 @@ class Chef
   class Provider::JenkinsPlugin < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides :jenkins_plugin
+    provides (:jenkins_plugin) if defined?(provides)
 
     class PluginNotInstalled < StandardError
       def initialize(plugin, action)

--- a/libraries/script.rb
+++ b/libraries/script.rb
@@ -34,7 +34,7 @@ end
 
 class Chef
   class Provider::JenkinsScript < Provider::JenkinsCommand
-    provides (:jenkins_script) if defined?(provides)
+    provides :jenkins_script if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsScript.new(new_resource.command)

--- a/libraries/script.rb
+++ b/libraries/script.rb
@@ -34,7 +34,7 @@ end
 
 class Chef
   class Provider::JenkinsScript < Provider::JenkinsCommand
-    provides :jenkins_script
+    provides (:jenkins_script) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsScript.new(new_resource.command)

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -117,7 +117,7 @@ class Chef
   class Provider::JenkinsSlave < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides (:jenkins_slave) if defined?(provides)
+    provides :jenkins_slave if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsSlave.new(new_resource.name)

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -117,7 +117,7 @@ class Chef
   class Provider::JenkinsSlave < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides :jenkins_slave
+    provides (:jenkins_slave) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsSlave.new(new_resource.name)

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -43,7 +43,7 @@ end
 
 class Chef
   class Provider::JenkinsJnlpSlave < Provider::JenkinsSlave
-    provides (:jenkins_jnlp_slave) if defined?(provides)
+    provides :jenkins_jnlp_slave if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsJnlpSlave.new(new_resource.name)

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -43,7 +43,7 @@ end
 
 class Chef
   class Provider::JenkinsJnlpSlave < Provider::JenkinsSlave
-    provides :jenkins_jnlp_slave
+    provides (:jenkins_jnlp_slave) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsJnlpSlave.new(new_resource.name)

--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -66,7 +66,7 @@ end
 
 class Chef
   class Provider::JenkinsSshSlave < Provider::JenkinsSlave
-    provides :jenkins_ssh_slave
+    provides (:jenkins_ssh_slave) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsSshSlave.new(new_resource.name)

--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -66,7 +66,7 @@ end
 
 class Chef
   class Provider::JenkinsSshSlave < Provider::JenkinsSlave
-    provides (:jenkins_ssh_slave) if defined?(provides)
+    provides :jenkins_ssh_slave if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsSshSlave.new(new_resource.name)

--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -56,7 +56,7 @@ end
 
 class Chef
   class Provider::JenkinsWindowsSlave < Provider::JenkinsJnlpSlave
-    provides :jenkins_windows_slave, platform: %w(windows)
+    provides :jenkins_windows_slave, platform: %w(windows) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsWindowsSlave.new(new_resource.name)

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -67,7 +67,7 @@ class Chef
   class Provider::JenkinsUser < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides (:jenkins_user) if defined?(provides)
+    provides :jenkins_user if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsUser.new(new_resource.id)

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -67,7 +67,7 @@ class Chef
   class Provider::JenkinsUser < Provider::LWRPBase
     include Jenkins::Helper
 
-    provides :jenkins_user
+    provides (:jenkins_user) if defined?(provides)
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsUser.new(new_resource.id)


### PR DESCRIPTION
### Description

LWRP Chef-11 backward compatibility. Provides syntax is a Chef 12 feature.

### Issues Resolved

* https://github.com/chef-cookbooks/jenkins/issues/426

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD