### PR TITLE
bump openjdk from Java 7 to Java 8

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -6,7 +6,7 @@ driver:
     - rm -f /etc/service/sshd/down
     - /etc/my_init.d/00_regen_ssh_host_keys.sh
     # Install Java
-    - apt-get install -y --no-install-recommends openjdk-7-jdk
+    - apt-get install -y --no-install-recommends openjdk-8-jdk
     # Install Jenkins
     - mkdir -p /usr/share/jenkins/
     - useradd -d /var/lib/jenkins -m -s /bin/bash jenkins

--- a/recipes/java.rb
+++ b/recipes/java.rb
@@ -35,9 +35,9 @@
 
 case node['platform_family']
 when 'debian'
-  package 'openjdk-7-jdk'
+  package 'openjdk-8-jdk'
 when 'rhel'
-  package 'java-1.7.0-openjdk'
+  package 'java-1.8.0-openjdk'
 else
   raise "`#{node['platform_family']}' is not supported!"
 end

--- a/spec/recipes/java_spec.rb
+++ b/spec/recipes/java_spec.rb
@@ -7,8 +7,8 @@ describe 'jenkins::java' do
                             .converge(described_recipe)
     end
 
-    it 'installs openjdk-9-jdk' do
-      expect(chef_run).to install_package('openjdk-9-jdk')
+    it 'installs openjdk-8-jdk' do
+      expect(chef_run).to install_package('openjdk-8-jdk')
     end
   end
 
@@ -18,8 +18,8 @@ describe 'jenkins::java' do
                             .converge(described_recipe)
     end
 
-    it 'installs java-1.9.0-openjdk' do
-      expect(chef_run).to install_package('java-1.9.0-openjdk')
+    it 'installs java-1.8.0-openjdk' do
+      expect(chef_run).to install_package('java-1.8.0-openjdk')
     end
   end
 

--- a/spec/recipes/java_spec.rb
+++ b/spec/recipes/java_spec.rb
@@ -7,8 +7,8 @@ describe 'jenkins::java' do
                             .converge(described_recipe)
     end
 
-    it 'installs openjdk-7-jdk' do
-      expect(chef_run).to install_package('openjdk-7-jdk')
+    it 'installs openjdk-9-jdk' do
+      expect(chef_run).to install_package('openjdk-9-jdk')
     end
   end
 
@@ -18,8 +18,8 @@ describe 'jenkins::java' do
                             .converge(described_recipe)
     end
 
-    it 'installs java-1.7.0-openjdk' do
-      expect(chef_run).to install_package('java-1.7.0-openjdk')
+    it 'installs java-1.9.0-openjdk' do
+      expect(chef_run).to install_package('java-1.9.0-openjdk')
     end
   end
 


### PR DESCRIPTION
### Description

Bumping openjdk from java 7 to java 8 to see if this resolves current smoke build.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


