### PR TITLE
Configure limits of java process on master

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -193,6 +193,14 @@ default['jenkins']['master'].tap do |master|
   master['runit']['sv_timeout'] = 7
 
   #
+  # The limits for the Java process running the master server.
+  # Example to configure the maximum number of open file descriptors:
+  #
+  #   node.set['jenkins']['master']['ulimits'] = { 'n' => 8192 }
+  #
+  master['ulimits'] = nil
+
+  #
   # Repository URL. Default is latest
   #
   master['repository'] = case node['platform_family']

--- a/templates/default/sv-jenkins-run.erb
+++ b/templates/default/sv-jenkins-run.erb
@@ -9,6 +9,10 @@
 exec 2>&1
 cd <%= node['jenkins']['master']['home'] %>
 touch jenkins.start
+<% limits = node['jenkins']['master']['ulimits'] %>
+<% if limits && !limits.empty? %>
+ulimit <% limits.each { |option, value| %>-<%= option %> <%= value %> <% } %>
+<% end %>
 exec chpst -u <%= node['jenkins']['master']['user'] %> -U <%= node['jenkins']['master']['user'] %> \
   env HOME=<%= node['jenkins']['master']['home'] %> \
   JENKINS_HOME=<%= node['jenkins']['master']['home'] %> \


### PR DESCRIPTION
### Description
Provides an attribute to configure the resource limits of the Java process running the Jenkins server. 

### Issues Resolved
None

### Check List
- [ X ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ X ] New functionality has been documented in the README if applicable
- [ X ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


