### PR TITLE
Check for the mailer plugin's availability

### DIFF
--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -101,8 +101,11 @@ class Chef
             user = hudson.model.User.get('#{new_resource.id}')
             user.setFullName('#{new_resource.full_name}')
 
-            email = new hudson.tasks.Mailer.UserProperty('#{new_resource.email}')
-            user.addProperty(email)
+            if (jenkins.model.Jenkins.instance.pluginManager.getPlugin('mailer')) {
+              propertyClass = this.class.classLoader.loadClass('hudson.tasks.Mailer$UserProperty')
+              email = propertyClass.newInstance('#{new_resource.email}')
+              user.addProperty(email)
+            }
 
             password = hudson.security.HudsonPrivateSecurityRealm.Details.fromPlainPassword('#{new_resource.password}')
             user.addProperty(password)


### PR DESCRIPTION
### Description

Checks if the mailer plugin is available before adding the email property to the newly-created Jenkins user.

Useful for Jenkins 2 where the mailer plugin is not installed by
default.

### Issues Resolved

#470 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


