### PR TITLE
Fetch credentials via ID instead of username

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -101,14 +101,14 @@ EOH
     # @param [String] groovy_variable_name
     # @return [String]
     #
-    def credentials_for_username_groovy(username, groovy_variable_name)
+    def credentials_for_id_groovy(id, groovy_variable_name)
       <<-EOH.gsub(/ ^{8}/, '')
         import jenkins.model.*
         import com.cloudbees.plugins.credentials.*
         import com.cloudbees.plugins.credentials.common.*
         import com.cloudbees.plugins.credentials.domains.*;
 
-        username_matcher = CredentialsMatchers.withUsername("#{username}")
+        id_matcher = CredentialsMatchers.withId("#{id}")
         available_credentials =
           CredentialsProvider.lookupCredentials(
             StandardUsernameCredentials.class,
@@ -120,7 +120,7 @@ EOH
         #{groovy_variable_name} =
           CredentialsMatchers.firstOrNull(
             available_credentials,
-            username_matcher
+            id_matcher
           )
       EOH
     end

--- a/libraries/credentials.rb
+++ b/libraries/credentials.rb
@@ -42,7 +42,7 @@ class Chef
     # Attributes
     attribute :id,
               kind_of: String,
-              default: lazy { SecureRandom.uuid }
+              required: true
 
     attr_writer :exists
 

--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -44,10 +44,6 @@ class Chef
     attribute :username,
               kind_of: String,
               name_attribute: true
-    attribute :id,
-              kind_of: String,
-              regex: UUID_REGEX, # Private Key credentials must still have a UUID based ID
-              default: lazy { SecureRandom.uuid }
     attribute :private_key,
               kind_of: [String, OpenSSL::PKey::RSA, OpenSSL::PKey::EC],
               required: true

--- a/libraries/credentials_user.rb
+++ b/libraries/credentials_user.rb
@@ -51,7 +51,7 @@ class Chef
     #
     def fetch_existing_credentials_groovy(groovy_variable_name)
       <<-EOH.gsub(/ ^{8}/, '')
-        #{credentials_for_username_groovy(new_resource.username, groovy_variable_name)}
+        #{credentials_for_id_groovy(new_resource.id, groovy_variable_name)}
       EOH
     end
 

--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -56,7 +56,7 @@ class Chef
     #
     def parsed_credentials
       if credentials.is_a?(Resource::JenkinsCredentials)
-        credentials.send(:username)
+        credentials.send(:id)
       else
         credentials.to_s
       end
@@ -121,11 +121,8 @@ class Chef
         command_suffix: 'slave.launcher.suffixStartSlaveCmd'
       }
 
-      map[:credentials] = if new_resource.parsed_credentials.match(UUID_REGEX)
-                            'slave.launcher.credentialsId'
-                          else
-                            'slave.launcher.credentialsId == null ? null : hudson.plugins.sshslaves.SSHLauncher.lookupSystemCredentials(slave.launcher.credentialsId).username'
-                          end
+      map[:credentials] = 'slave.launcher.credentialsId'
+
       map
     end
 
@@ -140,13 +137,9 @@ class Chef
     # @return [String]
     #
     def credential_lookup_groovy(groovy_variable_name = 'credentials_id')
-      if new_resource.parsed_credentials.match(UUID_REGEX)
-        "#{groovy_variable_name} = hudson.plugins.sshslaves.SSHLauncher.lookupSystemCredentials(#{convert_to_groovy(new_resource.parsed_credentials)})"
-      else
-        <<-EOH.gsub(/ ^{10}/, '')
-          #{credentials_for_username_groovy(new_resource.parsed_credentials, groovy_variable_name)}
-        EOH
-      end
+      <<-EOH.gsub(/ ^{10}/, '')
+        #{credentials_for_id_groovy(new_resource.parsed_credentials, groovy_variable_name)}
+      EOH
     end
   end
 end


### PR DESCRIPTION
### Description

Looking up credentials by username means that you can't have a password and a private key with the same username.  This leads to LOTS of confusion (see #447).

This also drops the UUID regex from the priv key credential, since [it's been able to accept any string as an ID for over a year now](https://issues.jenkins-ci.org/browse/JENKINS-26099).

### Issues Resolved

Fixes #447 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD