### PR TITLE
Make creating jenkins user and group optional

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -135,6 +135,11 @@ default['jenkins']['master'].tap do |master|
   master['use_system_accounts'] = true
 
   #
+  # Jenkins user/group should not be created unless you are letting something else (e.g. ldap) manage them
+  # The default of `true` means a local user/group will be created
+  master['create_user'] = true
+
+  #
   # The host the Jenkins master is running on. For single-installs, the default
   # value of +localhost+ will suffice. For multi-node installs, you will likely
   # need to update this attribute to the FQDN of your Jenkins master.

--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -28,12 +28,14 @@
 user node['jenkins']['master']['user'] do
   home node['jenkins']['master']['home']
   system node['jenkins']['master']['use_system_accounts'] # ~FC048
+  if { node['jenkins']['master']['create_user'] }
 end
 
 # Create the Jenkins group
 group node['jenkins']['master']['group'] do
   members node['jenkins']['master']['user']
   system node['jenkins']['master']['use_system_accounts'] # ~FC048
+  if { node['jenkins']['master']['create_user'] }
 end
 
 # Create the home directory


### PR DESCRIPTION
(not ready for merge yet)
### Description

Make the creation of a local jenkins user and group optional, in case something else (e.g. ldap) is managing the jenkins user.
### Issues Resolved

https://github.com/chef-cookbooks/jenkins/issues/395
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
