### PR TITLE
Add build matcher for jenkins_job

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -68,6 +68,13 @@ if defined?(ChefSpec)
   end
 
   ChefSpec.define_matcher :jenkins_job
+  def build_jenkins_job(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+      :jenkins_job,
+      :build,
+      resource_name)
+  end
+
   def create_jenkins_job(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(
       :jenkins_job,


### PR DESCRIPTION
### Description

Add ChefSpec matcher for `:build` action on the `jenkins_job` resource.

### Issues Resolved

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
