### PR TITLE
Use resource_for_node() instead of hardcoding User

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -160,7 +160,12 @@ class Chef
     #
     def user_resource
       return @user_resource if @user_resource
-      @user_resource = Chef::Resource::User.new(new_resource.user, run_context)
+      user_resource_class = if Chef::Resource.respond_to? :resource_for_node
+                              Chef::Resource.resource_for_node(:user, node)
+                            else
+                              Chef::Resource::User
+                            end
+      @user_resource = user_resource_class.new(new_resource.user, run_context)
       @user_resource.gid(new_resource.group)
       @user_resource.comment('Jenkins slave user - Created by Chef')
       @user_resource.home(new_resource.remote_fs)


### PR DESCRIPTION
With Chef 12.14.89 the `Chef::Resource::User` class isn't "real" and
throws `NotImplementedError` (with no message, grrr) and shows up
in the output as `user_resource_abstract_base_class`.

Instead, `Chef::Resource.resource_for_node(:user, node)` has to be
used to get the real user class (e.g. `LinuxUser`)

Fixes #513