### PR TITLE
Add use_inline_resource and use action DSL helper in all providers

### DIFF
--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -42,6 +42,7 @@ end
 
 class Chef
   class Provider::JenkinsCommand < Provider::LWRPBase
+    use_inline_resources
     include Jenkins::Helper
 
     provides :jenkins_command
@@ -57,7 +58,7 @@ class Chef
       true
     end
 
-    action(:execute) do
+    action :execute do
       converge_by("Execute #{new_resource}") do
         executor.execute!(new_resource.command)
       end

--- a/libraries/credentials.rb
+++ b/libraries/credentials.rb
@@ -85,7 +85,7 @@ class Chef
     #
     # Create the given credentials.
     #
-    action(:create) do
+    action :create do
       if current_resource.exists? && correct_config?
         Chef::Log.info("#{new_resource} exists - skipping")
       else
@@ -123,7 +123,7 @@ class Chef
     #
     # Delete the given credentials.
     #
-    action(:delete) do
+    action :delete do
       if current_resource.exists?
         converge_by("Delete #{new_resource}") do
           executor.groovy! <<-EOH.gsub(/ ^{12}/, '')

--- a/libraries/credentials.rb
+++ b/libraries/credentials.rb
@@ -60,6 +60,7 @@ end
 
 class Chef
   class Provider::JenkinsCredentials < Provider::LWRPBase
+    use_inline_resources
     include Jenkins::Helper
 
     def load_current_resource

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -39,6 +39,7 @@ end
 
 class Chef
   class Provider::JenkinsPasswordCredentials < Provider::JenkinsUserCredentials
+    use_inline_resources
     provides :jenkins_password_credentials
 
     def load_current_resource

--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -36,7 +36,6 @@ end
 
 class Chef
   class Resource::JenkinsPrivateKeyCredentials < Resource::JenkinsUserCredentials
-    use_inline_resources
     include Jenkins::Helper
 
     resource_name :jenkins_private_key_credentials

--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -36,6 +36,7 @@ end
 
 class Chef
   class Resource::JenkinsPrivateKeyCredentials < Resource::JenkinsUserCredentials
+    use_inline_resources
     include Jenkins::Helper
 
     resource_name :jenkins_private_key_credentials
@@ -76,6 +77,7 @@ end
 
 class Chef
   class Provider::JenkinsPrivateKeyCredentials < Provider::JenkinsUserCredentials
+    use_inline_resources
     provides :jenkins_private_key_credentials
 
     def load_current_resource

--- a/libraries/credentials_secret_text.rb
+++ b/libraries/credentials_secret_text.rb
@@ -41,6 +41,8 @@ end
 
 class Chef
   class Provider::JenkinsSecretTextCredentials < Provider::JenkinsCredentials
+    use_inline_resources
+
     provides :jenkins_secret_text_credentials
 
     def load_current_resource

--- a/libraries/credentials_user.rb
+++ b/libraries/credentials_user.rb
@@ -29,6 +29,7 @@ end
 
 class Chef
   class Provider::JenkinsUserCredentials < Provider::JenkinsCredentials
+    use_inline_resources
     include Jenkins::Helper
 
     def load_current_resource

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -126,7 +126,7 @@ EOH
     # @raise [JobDoesNotExist]
     #   if the job does not exist
     #
-    action(:build) do
+    action :build do
       unless current_resource.exists?
         raise JobDoesNotExist.new(new_resource.name, :build)
       end
@@ -188,7 +188,7 @@ EOH
     # Requirements:
     #   - `config` parameter
     #
-    action(:create) do
+    action :create do
       validate_config!
 
       if current_resource.exists?
@@ -213,7 +213,7 @@ EOH
     # the job does not exist, no action will be taken. If the job does exist,
     # it will be deleted using the Jenkins CLI.
     #
-    action(:delete) do
+    action :delete do
       if current_resource.exists?
         converge_by("Delete #{new_resource}") do
           executor.execute!('delete-job', escape(new_resource.name))
@@ -229,7 +229,7 @@ EOH
     # @raise [JobDoesNotExist]
     #   if the job does not exist
     #
-    action(:disable) do
+    action :disable do
       unless current_resource.exists?
         raise JobDoesNotExist.new(new_resource.name, :disable)
       end
@@ -249,7 +249,7 @@ EOH
     # @raise [JobDoesNotExist]
     #   if the job does not exist
     #
-    action(:enable) do
+    action :enable do
       unless current_resource.exists?
         raise JobDoesNotExist.new(new_resource.name, :enable)
       end

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -79,6 +79,8 @@ end
 
 class Chef
   class Provider::JenkinsJob < Provider::LWRPBase
+    use_inline_resources
+
     include Jenkins::Helper
 
     provides :jenkins_job

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -67,6 +67,7 @@ end
 
 class Chef
   class Provider::JenkinsPlugin < Provider::LWRPBase
+    use_inline_resources
     include Jenkins::Helper
 
     provides :jenkins_plugin

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -105,7 +105,7 @@ EOH
       true
     end
 
-    action(:install) do
+    action :install do
       # This block stores the actual command to execute, since its the same
       # for upgrades and installs.
       install_block = proc do
@@ -169,7 +169,7 @@ EOH
     # Plugins that are disabled can be re-enabled from the UI (or by removing
     # *.jpi.disabled file from the disk.)
     #
-    action(:disable) do
+    action :disable do
       unless current_resource.installed?
         raise PluginNotInstalled.new(new_resource.name, :disable)
       end
@@ -193,7 +193,7 @@ EOH
     #
     # Plugins may be disabled by re-adding the +.jpi.disabled+ plugin.
     #
-    action(:enable) do
+    action :enable do
       unless current_resource.installed?
         raise PluginNotInstalled.new(new_resource.name, :enable)
       end
@@ -225,7 +225,7 @@ EOH
     # those configurations that it didn't understand, and pretend as if it
     # didn't see such a fragment.
     #
-    action(:uninstall) do
+    action :uninstall do
       if current_resource.installed?
         converge_by("Uninstall #{new_resource}") do
           uninstall_plugin(new_resource.name)

--- a/libraries/script.rb
+++ b/libraries/script.rb
@@ -34,6 +34,7 @@ end
 
 class Chef
   class Provider::JenkinsScript < Provider::JenkinsCommand
+    use_inline_resources
     provides :jenkins_script
 
     def load_current_resource
@@ -48,7 +49,7 @@ class Chef
       true
     end
 
-    action(:execute) do
+    action :execute do
       converge_by("Execute script #{new_resource}") do
         executor.groovy!(new_resource.command)
       end

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -115,6 +115,8 @@ end
 
 class Chef
   class Provider::JenkinsSlave < Provider::LWRPBase
+    use_inline_resources
+
     include Jenkins::Helper
 
     provides :jenkins_slave
@@ -144,7 +146,7 @@ class Chef
       true
     end
 
-    def action_create
+    action :create do
       if current_resource.exists? && correct_config?
         Chef::Log.info("#{new_resource} exists - skipping")
       else
@@ -216,7 +218,7 @@ class Chef
       end
     end
 
-    def action_delete
+    action :delete do
       if current_resource.exists?
         converge_by("Delete #{new_resource}") do
           executor.execute!('delete-node', escape(new_resource.slave_name))
@@ -226,7 +228,7 @@ class Chef
       end
     end
 
-    def action_connect
+    action :connect do
       if current_resource.exists? && current_resource.connected?
         Chef::Log.debug("#{new_resource} already connected - skipping")
       else
@@ -236,7 +238,7 @@ class Chef
       end
     end
 
-    def action_disconnect
+    action :disconnect do
       if current_resource.connected?
         converge_by("Disconnect #{new_resource}") do
           executor.execute!('disconnect-node', escape(new_resource.slave_name))
@@ -246,7 +248,7 @@ class Chef
       end
     end
 
-    def action_online
+    action :online do
       if current_resource.exists? && current_resource.online?
         Chef::Log.debug("#{new_resource} already online - skipping")
       else
@@ -256,7 +258,7 @@ class Chef
       end
     end
 
-    def action_offline
+    action :offline do
       if current_resource.online?
         converge_by("Offline #{new_resource}") do
           command_pieces = [escape(new_resource.slave_name)]

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -43,6 +43,7 @@ end
 
 class Chef
   class Provider::JenkinsJnlpSlave < Provider::JenkinsSlave
+    use_inline_resources
     provides :jenkins_jnlp_slave
 
     def load_current_resource
@@ -50,7 +51,7 @@ class Chef
       super
     end
 
-    def action_create
+    action :create do
       super
 
       parent_remote_fs_dir_resource.run_action(:create)
@@ -71,7 +72,7 @@ class Chef
       service_resource.run_action(:restart) if slave_jar_resource.updated?
     end
 
-    def action_delete
+    action :delete do
       # Stop and remove the service
       service_resource.run_action(:disable)
 

--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -66,6 +66,7 @@ end
 
 class Chef
   class Provider::JenkinsSshSlave < Provider::JenkinsSlave
+    use_inline_resources
     provides :jenkins_ssh_slave
 
     def load_current_resource

--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -56,6 +56,7 @@ end
 
 class Chef
   class Provider::JenkinsWindowsSlave < Provider::JenkinsJnlpSlave
+    use_inline_resources
     provides :jenkins_windows_slave, platform: %w(windows)
 
     def load_current_resource
@@ -66,7 +67,7 @@ class Chef
     #
     # @see Chef::Resource::JenkinsSlave#action_create
     #
-    def action_create
+    action :create do
       super
 
       # The following resources are created in the parent:

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -90,7 +90,7 @@ class Chef
       true
     end
 
-    action(:create) do
+    action :create do
       if current_resource.exists? &&
          current_resource.full_name == new_resource.full_name &&
          current_resource.email == new_resource.email &&
@@ -120,7 +120,7 @@ class Chef
       end
     end
 
-    action(:delete) do
+    action :delete do
       if current_resource.exists?
         converge_by("Delete #{new_resource}") do
           executor.groovy! <<-EOH.gsub(/^ {12}/, '')

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -65,6 +65,7 @@ end
 
 class Chef
   class Provider::JenkinsUser < Provider::LWRPBase
+    use_inline_resources
     include Jenkins::Helper
 
     provides :jenkins_user


### PR DESCRIPTION
### Description

upgrade to best-practices, as should be enforced by several
foodcritic rules.  everything seems to ultimately inherit from
LWRPBase in this cookbook, which is somewhat pointless and/or buggy
if you don't declare use_inline_resources and then use the action
DSL helper instead of using `def action` directly.

it seems this cookbook mostly constructs its own sub-resources manually
and does not place them in a resource collection and does not gather
their updated_by_last_action state, so notifications off of the outer
resources here are likely still broken (or maybe this is by design
and nobody wants notifies to fire off of the subresources in some
of these providers, but that seems doubtful?)

anyway, i don't think this is a behavior change, but starts to drag
the cookbook style into 2014/2015 at least.

### Issues Resolved

none that i'm aware of, but probably a ton that look like should be getting reported (well, this wouldn't fix any directly, but would set the foundation for fixing them).

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

