### PR TITLE
pretty certain include_recipe can be used directly

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -229,9 +229,7 @@ class Chef
       return @service_resource if @service_resource
 
       # Ensure runit is installed on the slave.
-      recipe_eval do
-        run_context.include_recipe 'runit'
-      end
+      include_recipe 'runit'
 
       @service_resource = Chef::Resource::RunitService.new(new_resource.service_name, run_context)
       @service_resource.cookbook('jenkins')


### PR DESCRIPTION
this indirection has not been necessary for some time (exactly how long i'm not entirely positive, but long enough to forget when i added it to the recipe DSL)