### PR TITLE
Make sure private_key is String before checking ecdsa_key?

### DIFF
--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -135,6 +135,7 @@ class Chef
       # Normalize the private key
       if @current_credentials && @current_credentials[:private_key]
         cc = @current_credentials[:private_key]
+        cc = @current_credentials[:private_key].to_pem unless cc.is_a?(String)
         @current_credentials[:private_key] = ecdsa_key?(cc) ? OpenSSL::PKey::EC.new(cc) : OpenSSL::PKey::RSA.new(cc)
       end
 


### PR DESCRIPTION
Make sure private_key is String before checking ecdsa_key?

```
[2016-10-11T11:14:05+00:00] ERROR: jenkins_private_key_credentials[jenkins@xxx.com] (xxx-jenkins::credentials line 14) had an error: NoMethodError: undefined method `include?' for #<OpenSSL::PKey::RSA:0x00000017bd0328>
```