### PR TITLE
remove super from actions and private

### DIFF
--- a/libraries/credentials.rb
+++ b/libraries/credentials.rb
@@ -151,7 +151,7 @@ class Chef
       end
     end
 
-    protected
+    private
 
     #
     # Returns a Groovy snippet that creates an instance of the

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -54,7 +54,7 @@ class Chef
       @current_credentials
     end
 
-    protected
+    private
 
     #
     # @see Chef::Resource::JenkinsCredentials#credentials_groovy

--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -91,7 +91,7 @@ class Chef
       @current_resource
     end
 
-    protected
+    private
 
     #
     # @see Chef::Resource::JenkinsCredentials#credentials_groovy

--- a/libraries/credentials_secret_text.rb
+++ b/libraries/credentials_secret_text.rb
@@ -57,7 +57,7 @@ class Chef
       @current_credentials
     end
 
-    protected
+    private
 
     #
     # @see Chef::Resource::JenkinsCredentials#credentials_groovy

--- a/libraries/credentials_user.rb
+++ b/libraries/credentials_user.rb
@@ -44,7 +44,7 @@ class Chef
       @current_resource
     end
 
-    protected
+    private
 
     #
     # @see Chef::Resource::JenkinsCredentials#save_credentials_groovy

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -147,6 +147,10 @@ class Chef
     end
 
     action :create do
+      do_create
+    end
+
+    def do_create
       if current_resource.exists? && correct_config?
         Chef::Log.info("#{new_resource} exists - skipping")
       else
@@ -219,6 +223,10 @@ class Chef
     end
 
     action :delete do
+      do_delete
+    end
+
+    def do_delete
       if current_resource.exists?
         converge_by("Delete #{new_resource}") do
           executor.execute!('delete-node', escape(new_resource.slave_name))
@@ -272,7 +280,7 @@ class Chef
       end
     end
 
-    protected
+    private
 
     #
     # Returns a Groovy snippet that creates an instance of the slave's
@@ -301,8 +309,6 @@ class Chef
     def attribute_to_property_map
       {}
     end
-
-    private
 
     #
     # Loads the current slave into a Hash.

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -52,7 +52,7 @@ class Chef
     end
 
     action :create do
-      super
+      do_create
 
       parent_remote_fs_dir_resource.run_action(:create)
 
@@ -76,10 +76,10 @@ class Chef
       # Stop and remove the service
       service_resource.run_action(:disable)
 
-      super
+      do_delete
     end
 
-    protected
+    private
 
     #
     # @see Chef::Resource::JenkinsSlave#launcher_groovy

--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -129,8 +129,6 @@ class Chef
       map
     end
 
-    private
-
     #
     # A Groovy snippet that will set the requested local Groovy variable
     # to an instance of the credentials represented by

--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -85,7 +85,7 @@ class Chef
       @current_resource
     end
 
-    protected
+    private
 
     #
     # @see Chef::Resource::JenkinsSlave#launcher_groovy

--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -68,7 +68,7 @@ class Chef
     # @see Chef::Resource::JenkinsSlave#action_create
     #
     action :create do
-      super
+      do_create
 
       # The following resources are created in the parent:
       #
@@ -95,7 +95,7 @@ class Chef
       end
     end
 
-    protected
+    private
 
     # Embedded Resources
 


### PR DESCRIPTION

common code shouldn't use inheritance it should use mixins or
ideally composition -- the slave_jnlp providers should probably
use jenkins_slave sub-providers to do their work, but they do
not.

anyway super is busted, so do the minimum amount to move that to a
function which can then at least be called directly.

also it seems someone mistakenly thought they needed to use
`protected` so that subclasses could use methods, which is incorrect,
this is ruby, not java, subclasses can call all private methods in
the superclass (`protected` is weird in ruby -- it allows a receiver
to be a different instance of the same clas, which is occasionally
useful, but 99% of the time in our code `protected` is used when
`private` is meant).

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>