### PR TITLE
Fix for #531

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -206,8 +206,9 @@ class Chef
     # @return [Chef::Resource::RemoteFile]
     #
     def slave_jar_resource
+      slave_jar_remote_url = slave_jar_url
       @slave_jar_resource ||= build_resource(:remote_file, slave_jar) do
-        source(slave_jar_url)
+        source(slave_jar_remote_url)
         backup(false)
         mode('0755')
         atomic_update(false)

--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -79,7 +79,7 @@ class Chef
       # However, once it is created Jenkins Master wants to control the version.  So we should only
       # create the file if it is missing.
       slave_exe_resource.run_action(:create_if_missing)
-
+      slave_jar_resource.run_action(:create)
       slave_compat_xml.run_action(:create)
       slave_bat_resource.run_action(:create)
       slave_xml_resource.run_action(:create)


### PR DESCRIPTION
### Description

Correctly obtain the slave_jar_remote_url
Create the slave_jar_resource to create the slave.jar file for a windows slave

### Issues Resolved 
#531 
Windows JNLP slave fails on Windows slave

### Check List

- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
