### PR TITLE
updated the jenkins url and keys for redhat attributes. 

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -210,7 +210,7 @@ default['jenkins']['master'].tap do |master|
   #
   master['repository'] = case node['platform_family']
                          when 'debian' then 'http://pkg.jenkins-ci.org/debian'
-                         when 'rhel' then 'http://pkg.jenkins-ci.org/redhat'
+                         when 'rhel' then 'https://pkg.jenkins.io/redhat/jenkins.repo'
                          end
 
   #
@@ -218,7 +218,7 @@ default['jenkins']['master'].tap do |master|
   #
   master['repository_key'] = case node['platform_family']
                              when 'debian' then 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key'
-                             when 'rhel' then 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key'
+                             when 'rhel' then 'https://pkg.jenkins.io/redhat/jenkins.io.key'
                              end
 
   #


### PR DESCRIPTION
### Description

This fixes the installation of Jenkins on a RHEL/CentOS images.

### Issues Resolved

Currently the way the keys and the repo's that are being used will not install using bento/centos-7.2. There is an issue with the repo and keys aligning. I used these instructions [1] to verify the installation on base vagrant box. 

[1] http://pkg.jenkins-ci.org/redhat/

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>