### PR TITLE
Allow customization of MAXOPENFILES on ubuntu

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -185,6 +185,14 @@ default['jenkins']['master'].tap do |master|
   master['log_directory'] = '/var/log/jenkins'
 
   #
+  # Set the max open files to a specific value.
+  # Due to http://github.com/jenkinsci/jenkins/commit/2fb288474e980d0e7ff9c4a3b768874835a3e92e
+  # reporting that Ubuntu's PAM configuration doesn't include pam_limits.so, and as a result the # of file
+  # descriptors are forced to 1024 regardless of /etc/security/limits.conf
+  #
+  master['maxopenfiles'] = 8192
+
+  #
   # The groups of user under which Jenkins is running. Works for runit only.
   #
   master['runit']['groups'] = [node['jenkins']['master']['group']]

--- a/templates/default/jenkins-config-debian.erb
+++ b/templates/default/jenkins-config-debian.erb
@@ -40,7 +40,7 @@ JENKINS_LOG=<%= node['jenkins']['master']['log_directory'] %>/$NAME.log
 #   this is on by default because http://github.com/jenkinsci/jenkins/commit/2fb288474e980d0e7ff9c4a3b768874835a3e92e
 #   reported that Ubuntu's PAM configuration doesn't include pam_limits.so, and as a result the # of file
 #   descriptors are forced to 1024 regardless of /etc/security/limits.conf
-MAXOPENFILES=8192
+MAXOPENFILES=<%= node['jenkins']['master']['maxopenfiles'] %>
 
 # address bound to HTTP connector (default 0.0.0.0)
 HTTP_LISTEN_ADDRESS="<%= node['jenkins']['master']['listen_address'] %>"


### PR DESCRIPTION
### Description

Our jenkins installation is hitting the open files limit of 8192 and we need a way to override it. This change allow us to set the value to be whatever we want.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>