### PR TITLE
Fix the repo URL for RHEL based systems.

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -218,7 +218,7 @@ default['jenkins']['master'].tap do |master|
   #
   master['repository'] = case node['platform_family']
                          when 'debian' then 'http://pkg.jenkins-ci.org/debian'
-                         when 'rhel' then 'https://pkg.jenkins.io/redhat/jenkins.repo'
+                         when 'rhel' then 'https://pkg.jenkins.io/redhat'
                          end
 
   #


### PR DESCRIPTION
### Description

Currently this cookbook is broken on RHEL systems as the repo URL is incorrect:

```
# yum update
Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager, versionlock
This system is not registered with Subscription Management. You can use subscription-manager to register.
base                                                                                                                                                                                                                                                     | 3.6 kB  00:00:00     
chef                                                                                                                                                                                                                                                     | 1.4 kB  00:00:00     
custom                                                                                                                                                                                                                                                   | 2.9 kB  00:00:00     
epel                                                                                                                                                                                                                                                     | 4.3 kB  00:00:00     
extras                                                                                                                                                                                                                                                   | 3.4 kB  00:00:00     
https://pkg.jenkins.io/redhat/jenkins.repo/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
Trying other mirror.
To address this issue please refer to the below knowledge base article 

https://access.redhat.com/articles/1320623
```

The URL was updated to that of the example yum config and not the repo itself. This change updates the appropriate attribute to the correct URL.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
