### PR TITLE
fixed jenkins repo url

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -218,7 +218,7 @@ default['jenkins']['master'].tap do |master|
   #
   master['repository'] = case node['platform_family']
                          when 'debian' then 'http://pkg.jenkins-ci.org/debian'
-                         when 'rhel' then 'https://pkg.jenkins.io/redhat/jenkins.repo'
+                         when 'rhel' then 'https://pkg.jenkins.io/redhat'
                          end
 
   #


### PR DESCRIPTION
The jenkins.repo is a sample repo file, not the actual url.  corrected to be the actual correct url.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
