### PR TITLE
Use HTTPS when downloading the WAR, and for Debian repos

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -112,14 +112,14 @@ suites:
       jenkins:
         master:
           install_method: war
-          source: http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war
+          source: https://updates.jenkins.io/stable/latest/jenkins.war
   - name: smoke_war_latest
     run_list: jenkins_server_wrapper::default
     attributes:
       jenkins:
         master:
           install_method: war
-          source: http://mirrors.jenkins-ci.org/war/latest/jenkins.war
+          source: https://updates.jenkins.io/latest/jenkins.war
 
   #
   # Authentication suites

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,7 @@ provisioner:
       master:
         host: localhost
         install_method: war
-        mirror: http://mirrors.jenkins-ci.org
+        mirror: https://updates.jenkins.io
 
 platforms:
   - name: ubuntu-14.04
@@ -43,14 +43,14 @@ suites:
       jenkins:
         master:
           install_method: war
-          source: http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war
+          source: https://updates.jenkins.io/stable/latest/jenkins.war
   - name: smoke_war_latest
     run_list: jenkins_server_wrapper::default
     attributes:
       jenkins:
         master:
           install_method: war
-          source: http://mirrors.jenkins-ci.org/war/latest/jenkins.war
+          source: https://updates.jenkins.io/latest/jenkins.war
 
   #
   # Authentication suites

--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -55,7 +55,7 @@ default['jenkins']['master'].tap do |master|
   # more interested in the +source+ attribute, which accepts the full path
   # to the war file for downloading.
   #
-  master['mirror'] = 'http://mirrors.jenkins-ci.org'
+  master['mirror'] = 'https://updates.jenkins.io'
 
   #
   # The full URL to the Jenkins WAR file on the remote mirror. This attribute is
@@ -70,7 +70,7 @@ default['jenkins']['master'].tap do |master|
   # Warning: Setting this attribute will negate/ignore any values for +mirror+
   # and +version+.
   #
-  master['source'] = "#{node['jenkins']['master']['mirror']}/war/#{node['jenkins']['master']['version'] || 'latest'}/jenkins.war"
+  master['source'] = "#{node['jenkins']['master']['mirror']}/#{node['jenkins']['master']['version'] || 'current'}/latest/jenkins.war"
 
   #
   # The checksum of the war file. This is use to verify that the remote war file
@@ -217,7 +217,7 @@ default['jenkins']['master'].tap do |master|
   # Repository URL. Default is latest
   #
   master['repository'] = case node['platform_family']
-                         when 'debian' then 'http://pkg.jenkins-ci.org/debian'
+                         when 'debian' then 'https://pkg.jenkins.io/debian'
                          when 'rhel' then 'https://pkg.jenkins.io/redhat'
                          end
 
@@ -225,7 +225,7 @@ default['jenkins']['master'].tap do |master|
   # Repository key. Default is latest
   #
   master['repository_key'] = case node['platform_family']
-                             when 'debian' then 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key'
+                             when 'debian' then 'https://pkg.jenkins.io/debian/jenkins.io.key'
                              when 'rhel' then 'https://pkg.jenkins.io/redhat/jenkins.io.key'
                              end
 


### PR DESCRIPTION
### Description

Use encryption (HTTPS) to fetch the WAR, and for Debian repositories.

For the WAR, this helps prevent man-in-the-middle attacks by default (`jenkins['master']['checksum'] = nil`).

For Debian repos, this provides defense in depth should something like https://www.debian.org/security/2016/dsa-3733 happen again.

The spec tests pass, but I couldn't get the TK tests to pass. It looks like Jenkins is still starting up when the ServerSpec tests try to run. This happens even on the unmodified code with the latest ChefDK etc., so I'll rely on Travis to run the tests.

This is my first time contributing to a community cookbook, so please let me know if I'm missing anything else! 😃 

```
       Transferring files to <smoke-war-latest-ubuntu-1604>
-----> Running serverspec test suite
-----> Installing Serverspec..
Fetching: diff-lcs-1.3.gem (100%)
Fetching: rspec-expectations-3.5.0.gem (100%)
Fetching: rspec-mocks-3.5.0.gem (100%)
Fetching: rspec-3.5.0.gem (100%)
Fetching: rspec-its-1.2.0.gem (100%)
Fetching: multi_json-1.12.1.gem (100%)
Fetching: net-ssh-4.0.1.gem (100%)
Fetching: net-scp-1.2.1.gem (100%)
Fetching: net-telnet-0.1.1.gem (100%)
Fetching: sfl-2.3.gem (100%)
Fetching: specinfra-2.66.5.gem (100%)
Fetching: serverspec-2.38.0.gem (100%)
-----> serverspec installed (version 2.38.0)
       /opt/chef/embedded/bin/ruby -I/tmp/verifier/suites/serverspec -I/tmp/verifier/gems/gems/rspec-support-3.5.0/lib:/tmp/verifier/gems/gems/rspec-core-3.5.4/lib /opt/chef/embedded/bin/rspec --pattern /tmp/verifier/suites/serverspec/\*\*/\*_spec.rb --color --format documentation --default-path /tmp/verifier/suites/serverspec
       /opt/chef/embedded/lib/ruby/2.3.0/json/common.rb:156:in `parse': 784: unexpected token at '<!DOCTYPE html><html><head resURL="/static/02e383ac" data-rooturl="" data-resurl="/static/02e383ac"> (JSON::ParserError)


           <title>Jenkins [Jenkins]</title><link rel="stylesheet" href="/static/02e383ac/css/layout-common.css" type="text/css" /><link rel="stylesheet" href="/static/02e383ac/css/style.css" type="text/css" /><link rel="stylesheet" href="/static/02e383ac/css/color.css" type="text/css" /><link rel="stylesheet" href="/static/02e383ac/css/responsive-grid.css" type="text/css" /><link rel="shortcut icon" href="/static/02e383ac/favicon.ico" type="image/vnd.microsoft.icon" /><link color="black" rel="mask-icon" href="/images/mask-icon.svg" /><script>var isRunAsTest=false; var rootURL=""; var resURL="/static/02e383ac";</script><script src="/static/02e383ac/scripts/prototype.js" type="text/javascript"></script><script src="/static/02e383ac/scripts/behavior.js" type="text/javascript"></script><script src='/adjuncts/02e383ac/org/kohsuke/stapler/bind.js' type='text/javascript'></script><script src="/static/02e383ac/scripts/yui/yahoo/yahoo-min.js"></script><script src="/static/02e383ac/scripts/yui/dom/dom-min.js"></script><script src="/static/02e383ac/scripts/yui/event/event-min.js"></script><script src="/static/02e383ac/scripts/yui/animation/animation-min.js"></script><script src="/static/02e383ac/scripts/yui/dragdrop/dragdrop-min.js"></script><script src="/static/02e383ac/scripts/yui/container/container-min.js"></script><script src="/static/02e383ac/scripts/yui/connection/connection-min.js"></script><script src="/static/02e383ac/scripts/yui/datasource/datasource-min.js"></script><script src="/static/02e383ac/scripts/yui/autocomplete/autocomplete-min.js"></script><script src="/static/02e383ac/scripts/yui/menu/menu-min.js"></script><script src="/static/02e383ac/scripts/yui/element/element-min.js"></script><script src="/static/02e383ac/scripts/yui/button/button-min.js"></script><script src="/static/02e383ac/scripts/yui/storage/storage-min.js"></script><script src="/static/02e383ac/scripts/hudson-behavior.js" type="text/javascript"></script><script src="/static/02e383ac/scripts/sortable.js" type="text/javascript"></script><script>crumb.init("", "");</script><link rel="stylesheet" href="/static/02e383ac/scripts/yui/container/assets/container.css" type="text/css" /><link rel="stylesheet" href="/static/02e383ac/scripts/yui/assets/skins/sam/skin.css" type="text/css" /><link rel="stylesheet" href="/static/02e383ac/scripts/yui/container/assets/skins/sam/container.css" type="text/css" /><link rel="stylesheet" href="/static/02e383ac/scripts/yui/button/assets/skins/sam/button.css" type="text/css" /><link rel="stylesheet" href="/static/02e383ac/scripts/yui/menu/assets/skins/sam/menu.css" type="text/css" /><link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Jenkins" /><meta name="ROBOTS" content="INDEX,NOFOLLOW" /><meta name="viewport" content="width=device-width, initial-scale=1" /><script src="/static/02e383ac/jsbundles/page-init.js" type="text/javascript"></script></head><body data-model-type="hudson.util.HudsonIsLoading" id="jenkins" class="yui-skin-sam jenkins-2.42 two-column" data-version="2.42"><a href="#skip2content" class="skiplink">Skip to content</a><div id="page-head"><div id="header"><div class="logo"><a id="jenkins-home-link" href="/"><img src="/static/02e383ac/images/headshot.png" alt="title" id="jenkins-head-icon" /><img src="/static/02e383ac/images/title.png" alt="title" width="139" id="jenkins-name-icon" height="34" /></a></div><div class="login"></div><div class="searchbox hidden-xs"><form method="get" name="search" style="position:relative;" class="no-json"><div id="search-box-minWidth"></div><div id="search-box-sizer"></div><div id="searchform"><input name="q" placeholder="search" id="search-box" class="has-default-text" /> <a href="http://wiki.jenkins-ci.org/display/JENKINS/Search+Box"><img src="/static/02e383ac/images/16x16/help.png" style="width: 16px; height: 16px; " class="icon-help icon-sm" /></a><div id="search-box-completion"></div><script>createSearchBox("");</script></div></form></div></div><div id="breadcrumbBar"><tr id="top-nav"><td id="left-top-nav" colspan="2"><link rel='stylesheet' href='/adjuncts/02e383ac/lib/layout/breadcrumbs.css' type='text/css' /><script src='/adjuncts/02e383ac/lib/layout/breadcrumbs.js' type='text/javascript'></script><div class="top-sticker noedge"><div class="top-sticker-inner"><div id="right-top-nav"><div id="right-top-nav"><div class="smallfont"><a href="?auto_refresh=true">ENABLE AUTO REFRESH</a></div></div></div><ul id="breadcrumbs"></ul><div id="breadcrumb-menu-target"></div></div></div></td></tr></div></div><div id="page-body" class="clear"><div id="side-panel"></div><div id="main-panel"><a name="skip2content"></a><h1 style="margin-top:4em">
        Please wait while Jenkins is getting ready to work<span id="progress">...</span></h1><p style="color:gray">Your browser will reload automatically when Jenkins is ready.</p><script>applySafeRedirector(window.location.href)</script></div></div><footer><div class="container-fluid"><div class="row"><div class="col-md-6" id="footer"></div><div class="col-md-18"><span class="page_generated">Page generated: Jan 23, 2017 6:09:40 PM UTC</span><span class="jenkins_ver"><a href="http://jenkins-ci.org/">Jenkins ver. 2.42</a></span><script type="text/javascript">
           var defaultUpdateSiteId = 'default';
           var setupWizardExtensions = [];
           var onSetupWizardInitialized = function(extension) {
             setupWizardExtensions.push(extension);
           };
         </script><script src="/static/02e383ac/jsbundles/pluginSetupWizard.js" type="text/javascript"></script><link rel="stylesheet" href="/static/02e383ac/jsbundles/pluginSetupWizard.css" type="text/css" /><script>Behaviour.addLoadEvent(function() {
        loadScript("https://usage.jenkins.io/usage-stats.js?QPF0OPrQy28PIzerf9nl0ZxoJdTjFg1gA+dkbbULRUnHLQWffy7Djj8lTM3mRAhpTnpaar2K4zGEd4K1jltWvTxEPgiCkkccG1VBzkVo8VzmyGPw+u8kOzBqp1SfbQF6726haBRZdcCLXs5V1TQ4jSuSo3Qnl8Fz1tpcXZn2anStwO4eUQNmUGkKVrWbm8AWS/iCeY+x0H92wV0TnNmy2QhQKkIeVNH0oEAlNUrD8C5pqUAgo58yKha/xUD39v7XOkYA2T/KesVvZ9KR+oqdYVa1DxhWm4VGC+FwfALBaLl/xJ4e0Yij9wHmTT56GSoFd8ePI5gVlj8Sqdm0PqWXBAxjXVeitHE04A/8ydcklKo6oUiHCAymm0lt/vkgYNVenHSKaf4WbkoB7Mp3Bko3qh1P6Fj+9okWxlqXjl+NBwsBXQ7k7cOZDHY3kVAqjZt9NVg3dffzo4+86sqYiwI9h6W09rRaXFTancvyqDyMkhzc6e8bqCSxsxZ4uookwqN/5U3gGcoctUe65xREyqgjOQ==");
             });</script></div></div></div></footer></body></html>'
       	from /opt/chef/embedded/lib/ruby/2.3.0/json/common.rb:156:in `parse'
       	from /tmp/verifier/suites/serverspec/support/jenkins_build.rb:57:in `resolve_build_tag_to_number'
       	from /tmp/verifier/suites/serverspec/support/jenkins_build.rb:15:in `initialize'
       	from /tmp/verifier/suites/serverspec/support/dsl.rb:6:in `new'
       	from /tmp/verifier/suites/serverspec/support/dsl.rb:6:in `jenkins_build'
       	from /tmp/verifier/suites/serverspec/assert_job_built_spec.rb:8:in `<top (required)>'
       	from /tmp/verifier/gems/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1435:in `load'
       	from /tmp/verifier/gems/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1435:in `block in load_spec_files'
       	from /tmp/verifier/gems/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `each'
       	from /tmp/verifier/gems/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `load_spec_files'
       	from /tmp/verifier/gems/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:100:in `setup'
       	from /tmp/verifier/gems/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:86:in `run'
       	from /tmp/verifier/gems/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
       	from /tmp/verifier/gems/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
       	from /tmp/verifier/gems/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
       	from /opt/chef/embedded/bin/rspec:22:in `load'
       	from /opt/chef/embedded/bin/rspec:22:in `<main>'
       /opt/chef/embedded/bin/ruby -I/tmp/verifier/suites/serverspec -I/tmp/verifier/gems/gems/rspec-support-3.5.0/lib:/tmp/verifier/gems/gems/rspec-core-3.5.4/lib /opt/chef/embedded/bin/rspec --pattern /tmp/verifier/suites/serverspec/\*\*/\*_spec.rb --color --format documentation --default-path /tmp/verifier/suites/serverspec failed
       !!!!!! Ruby Script [/tmp/verifier/gems/gems/busser-serverspec-0.5.10/lib/busser/runner_plugin/../serverspec/runner.rb /tmp/verifier/suites/serverspec] exit code was 1
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Verify failed on instance <smoke-war-latest-ubuntu-1604>.  Please see .kitchen/logs/smoke-war-latest-ubuntu-1604.log for more details
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
