### PR TITLE
Add blazemeter and sauce credentials resources

### DIFF
--- a/libraries/credentials_blazemeter.rb
+++ b/libraries/credentials_blazemeter.rb
@@ -1,0 +1,103 @@
+class Chef
+  class Resource::JenkinsBlazemeterCredentials < Resource::JenkinsCredentials
+    resource_name :jenkins_blazemeter_credentials
+
+    # Chef attributes
+    identity_attr :description
+
+    # Attributes
+    attribute :description,
+              kind_of: String,
+              name_attribute: true
+    attribute :api_key,
+              kind_of: String,
+              required: true
+  end
+end
+
+class Chef
+  class Provider::JenkinsBlazemeterCredentials < Provider::JenkinsCredentials
+    use_inline_resources
+
+    provides :jenkins_blazemeter_credentials
+
+    def load_current_resource
+      @current_resource ||= Resource::JenkinsBlazemeterCredentials.new(new_resource.name)
+
+      super
+
+      if current_credentials
+        @current_resource.api_key(current_credentials[:api_key])
+      end
+
+      @current_credentials
+    end
+
+    private
+
+    def credentials_groovy
+      <<-EOH.gsub(/ ^{8}/, '')
+        import hudson.plugins.blazemeter.BlazemeterCredentialImpl
+        credentials = new hudson.plugins.blazemeter.BlazemeterCredentialImpl(
+          #{convert_to_groovy(new_resource.api_key)}, #{convert_to_groovy(new_resource.description)})
+      EOH
+    end
+
+    def fetch_existing_credentials_groovy(groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+#{blazemeter_credentials_for_description_groovy(new_resource.description, groovy_variable_name)}
+      EOH
+    end
+
+    def resource_attributes_groovy(groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+#{groovy_variable_name} = [
+          id:credentials.id,
+          description:credentials.description,
+          api_key:credentials.apiKey
+        ]
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#attribute_to_property_map
+    #
+    def attribute_to_property_map
+      { api_key: 'credentials.apiKey' }
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#correct_config?
+    #
+    def correct_config?
+      wanted_credentials = {
+          description: new_resource.description,
+          api_key: new_resource.api_key
+      }
+
+      attribute_to_property_map.keys.each do |key|
+        wanted_credentials[key] = new_resource.send(key)
+      end
+
+      # Don't compare the ID as it is generated
+      current_credentials.dup.tap { |c| c.delete(:id) } == convert_blank_values_to_nil(wanted_credentials)
+    end
+
+    def blazemeter_credentials_for_description_groovy(description, groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+        import jenkins.model.Jenkins;
+        import com.cloudbees.plugins.credentials.CredentialsProvider
+        import hudson.plugins.blazemeter.BlazemeterCredentialImpl
+        available_credentials =
+          CredentialsProvider.lookupCredentials(
+            BlazemeterCredentialImpl.class,
+            Jenkins.getInstance(),
+            hudson.security.ACL.SYSTEM
+          ).findAll({
+            it.description == #{convert_to_groovy(description)}
+          })
+        #{groovy_variable_name} = available_credentials.size() > 0 ? available_credentials[0] : null
+      EOH
+    end
+  end
+end

--- a/libraries/credentials_sauce_ondemand.rb
+++ b/libraries/credentials_sauce_ondemand.rb
@@ -1,0 +1,53 @@
+class Chef
+  class Resource::JenkinsSauceOndemandCredentials < Resource::JenkinsUserCredentials
+    resource_name :jenkins_sauce_ondemand_credentials
+
+    # Attributes
+    attribute :username,
+              kind_of: String,
+              name_attribute: true
+    attribute :api_key,
+              kind_of: String,
+              required: true
+  end
+end
+
+class Chef
+  class Provider::JenkinsSauceOndemandCredentials < Provider::JenkinsUserCredentials
+    use_inline_resources
+    provides :jenkins_sauce_ondemand_credentials
+
+    def load_current_resource
+      @current_resource ||= Resource::JenkinsSauceOndemandCredentials.new(new_resource.name)
+
+      super
+
+      if current_credentials
+        @current_resource.api_key(current_credentials[:api_key])
+      end
+
+      @current_credentials
+    end
+
+    private
+
+    def credentials_groovy
+      <<-EOH.gsub(/ ^{8}/, '')
+        import com.cloudbees.plugins.credentials.*
+        import hudson.plugins.sauce_ondemand.credentials.SauceCredentials
+
+        credentials = new SauceCredentials(
+          CredentialsScope.GLOBAL,
+          #{convert_to_groovy(new_resource.id)},
+          #{convert_to_groovy(new_resource.username)},
+          #{convert_to_groovy(new_resource.api_key)},
+          #{convert_to_groovy(new_resource.description)}
+        )
+      EOH
+    end
+
+    def attribute_to_property_map
+      { api_key: 'credentials.apiKey.plainText' }
+    end
+  end
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -67,6 +67,36 @@ if defined?(ChefSpec)
       resource_name)
   end
 
+  ChefSpec.define_matcher :jenkins_sauce_ondemand_credentials
+  def create_jenkins_sauce_ondemand_credentials(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+        :jenkins_sauce_ondemand_credentials,
+        :create,
+        resource_name)
+  end
+
+  def delete_jenkins_sauce_ondemand_credentials(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+        :jenkins_sauce_ondemand_credentials,
+        :delete,
+        resource_name)
+  end
+
+  ChefSpec.define_matcher :jenkins_blazemeter_credentials
+  def create_jenkins_blazemeter_credentials(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+        :jenkins_blazemeter_credentials,
+        :create,
+        resource_name)
+  end
+
+  def delete_jenkins_blazemeter_credentials(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+        :jenkins_blazemeter_credentials,
+        :delete,
+        resource_name)
+  end
+
   ChefSpec.define_matcher :jenkins_job
   def build_jenkins_job(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
@@ -69,3 +69,27 @@ end
 jenkins_secret_text_credentials 'dollarbills_secret' do
   secret '$uper$ecret'
 end
+
+# Plugin required for Sauce OnDemand credentials
+jenkins_plugin 'sauce-ondemand' do
+  install_deps true
+  notifies :restart, 'service[jenkins]', :immediately
+end
+
+# Test creating Sauce OnDemand credentials
+jenkins_sauce_ondemand_credentials 'Sauce OnDemand test credentials' do
+  id          '855864a9-e1ea-4ee1-b769-e159681cb893'
+  description 'Sauce OnDemand credentials description'
+  api_key     'Sauce OnDemand test credentials'
+end
+
+# Plugin required for BlazeMeter credentials
+jenkins_plugin 'BlazeMeterJenkinsPlugin' do
+  install_deps true
+  notifies :restart, 'service[jenkins]', :immediately
+end
+
+# Test creating BlazeMeter credentials
+jenkins_blazemeter_credentials 'BlazeMeter credentials description' do
+  api_key     'BlazeMeter test credentials'
+end

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/delete.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/delete.rb
@@ -34,3 +34,11 @@ end
 jenkins_secret_text_credentials 'dollarbills_secret' do
   action :delete
 end
+
+jenkins_sauce_ondemand_credentials 'Sauce OnDemand test credentials' do
+  action :delete
+end
+
+jenkins_blazemeter_credentials 'BlazeMeter credentials description' do
+  action :delete
+end

--- a/test/integration/helpers/serverspec/support/dsl.rb
+++ b/test/integration/helpers/serverspec/support/dsl.rb
@@ -29,6 +29,14 @@ module RSpec
       def jenkins_user_credentials(username)
         Serverspec::Type::JenkinsUserCredentials.new(username)
       end
+
+      def jenkins_sauce_ondemand_credentials(username)
+        Serverspec::Type::JenkinsSauceOndemandCredentials.new(username)
+      end
+
+      def jenkins_blazemeter_credentials(name)
+        Serverspec::Type::JenkinsBlazemeterCredentials  .new(name)
+      end
     end
   end
 end

--- a/test/integration/helpers/serverspec/support/jenkins_credentials.rb
+++ b/test/integration/helpers/serverspec/support/jenkins_credentials.rb
@@ -107,5 +107,11 @@ module Serverspec
         @xml = nil
       end
     end
+
+    class JenkinsSauceOndemandCredentials < JenkinsUserCredentials
+    end
+
+    class JenkinsBlazemeterCredentials < JenkinsCredentials
+    end
   end
 end

--- a/test/integration/jenkins_credentials_create/serverspec/assert_created_spec.rb
+++ b/test/integration/jenkins_credentials_create/serverspec/assert_created_spec.rb
@@ -53,7 +53,14 @@ describe jenkins_user_credentials('dollarbills') do
   it { should have_password('$uper$ecret') }
 end
 
-describe jenkins_secret_text_credentials('dollarbills_secret') do
+describe jenkins_sauce_ondemand_credentials('Sauce OnDemand test credentials') do
   it { should be_a_jenkins_credentials }
-  it { should have_secret('$uper$ecret') }
+  it { should have_id('855864a9-e1ea-4ee1-b769-e159681cb893') }
+  it { should have_description('Sauce OnDemand credentials description') }
+  it { should have_secret('Sauce OnDemand test credentials') }
+end
+
+describe jenkins_blazemeter_credentials('BlazeMeter credentials description') do
+  it { should be_a_jenkins_credentials }
+  it { should have_secret('BlazeMeter test credentials') }
 end

--- a/test/integration/jenkins_credentials_delete/serverspec/assert_deleted_spec.rb
+++ b/test/integration/jenkins_credentials_delete/serverspec/assert_deleted_spec.rb
@@ -5,3 +5,11 @@ require 'spec_helper'
     it { should_not be_a_jenkins_credentials }
   end
 end
+
+describe jenkins_sauce_ondemand_credentials('Sauce OnDemand test credentials') do
+  it { should_not be_a_jenkins_credentials }
+end
+
+describe jenkins_blazemeter_credentials('BlazeMeter credentials description') do
+  it { should_not be_a_jenkins_credentials }
+end


### PR DESCRIPTION
### Description

This PR adding `jenkins_sauce_ondemand_credentials` and `jenkins_blazemeter_credentials` resources

### Issues Resolved

https://github.com/chef-cookbooks/jenkins/issues/546

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Obvious fix.
