### PR TITLE
Fixing Class.set is deprecated warnings

### DIFF
--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -66,6 +66,7 @@ end
 
 class Chef
   class Provider::JenkinsPlugin < Provider::LWRPBase
+    provides :jenkins_plugin
     use_inline_resources
     include Jenkins::Helper
 
@@ -439,8 +440,3 @@ EOH
     end
   end
 end
-
-Chef::Platform.set(
-  resource: :jenkins_plugin,
-  provider: Chef::Provider::JenkinsPlugin
-)

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -114,6 +114,7 @@ end
 
 class Chef
   class Provider::JenkinsSlave < Provider::LWRPBase
+    provides :jenkins_slave
     use_inline_resources
 
     include Jenkins::Helper
@@ -413,8 +414,3 @@ class Chef
     end
   end
 end
-
-Chef::Platform.set(
-  resource: :jenkins_slave,
-  provider: Chef::Provider::JenkinsSlave
-)

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -64,6 +64,7 @@ end
 
 class Chef
   class Provider::JenkinsUser < Provider::LWRPBase
+    provides :jenkins_user
     use_inline_resources
     include Jenkins::Helper
 
@@ -182,8 +183,3 @@ class Chef
     end
   end
 end
-
-Chef::Platform.set(
-  resource: :jenkins_user,
-  provider: Chef::Provider::JenkinsUser
-)


### PR DESCRIPTION
### Description

Removes three Chef::Platform.set() calls which are causing a deprecation warning.

```
[2017-01-26T13:44:37-06:00] WARN: Class.set is deprecated (CHEF-13)/tmp/d20170126-20624-efj0hq/cookbooks/jenkins/libraries/user.rb:186:in `<top (required)>'.
Please see https://docs.chef.io/deprecations_chef_platform_methods.html for further details and information on how to correct this problem. at /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.18.31/lib/chef/event_dispatch/dispatcher.rb:43:in `call'
.[2017-01-26T13:44:37-06:00] WARN: Class.set is deprecated (CHEF-13)/tmp/d20170126-20624-efj0hq/cookbooks/jenkins/libraries/plugin.rb:443:in `<top (required)>'.
Please see https://docs.chef.io/deprecations_chef_platform_methods.html for further details and information on how to correct this problem. at /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.18.31/lib/chef/event_dispatch/dispatcher.rb:43:in `call'
[2017-01-26T13:44:37-06:00] WARN: Class.set is deprecated (CHEF-13)/tmp/d20170126-20624-efj0hq/cookbooks/jenkins/libraries/slave.rb:417:in `<top (required)>'.
Please see https://docs.chef.io/deprecations_chef_platform_methods.html for further details and information on how to correct this problem. at /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.18.31/lib/chef/event_dispatch/dispatcher.rb:43:in `call'
```

### Issues Resolved

None

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
