### PR TITLE
jenkins_script using Groovy from path

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ jenkins_script 'add_authentication' do
 end
 ```
 
+```ruby
+template ::File.join(Chef::Config[:file_cache_path], 'create_jenkins_user' + '.groovy') do
+  source "create_jenkins_user.groovy.erb"
+  mode '0644'
+  owner 'jenkins'
+  group 'jenkins'
+  variables(
+    users: users
+  )
+  notifies :execute, "jenkins_script[create_jenkins_user]", :immediately
+end
+
+jenkins_script 'create_jenkins_user' do
+  groovy_path ::File.join(Chef::Config[:file_cache_path], 'create_jenkins_user' + '.groovy')
+end
+```
+
 ### jenkins\_credentials
 
 **NOTES** 

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -154,6 +154,10 @@ module Jenkins
       file.close! if file
     end
 
+    def groovy_from_file!(path)
+      execute!("groovy #{path}")
+    end
+
     private
 
     #

--- a/test/fixtures/cookbooks/jenkins_script/recipes/execute.rb
+++ b/test/fixtures/cookbooks/jenkins_script/recipes/execute.rb
@@ -18,3 +18,31 @@ jenkins_script 'create user' do
     user.save()
   EOH
 end
+
+users = [
+  {
+    "short_name" => "badger",
+    "full_name" => "Badger Badger",
+    "email" => "badger@chef.io"
+  },
+  {
+    "short_name" => "foo",
+    "full_name" => "Foo Foo",
+    "email" => "foo@chef.io"
+  }
+]
+
+template ::File.join(Chef::Config[:file_cache_path], 'create_jenkins_user' + '.groovy') do
+  source "create_jenkins_user.groovy.erb"
+  mode '0644'
+  owner 'jenkins'
+  group 'jenkins'
+  variables(
+    users: users
+  )
+  notifies :execute, "jenkins_script[create_jenkins_user]", :immediately
+end
+
+jenkins_script 'create_jenkins_user' do
+  groovy_path ::File.join(Chef::Config[:file_cache_path], 'create_jenkins_user' + '.groovy')
+end

--- a/test/fixtures/cookbooks/jenkins_script/templates/default/create_jenkins_user.groovy.erb
+++ b/test/fixtures/cookbooks/jenkins_script/templates/default/create_jenkins_user.groovy.erb
@@ -1,0 +1,7 @@
+<% @users.each do |user| %>
+user = hudson.model.User.get("<%= user['short_name'] %>")
+user.setFullName("<%= user['long_name'] %>")
+email = new hudson.tasks.Mailer.UserProperty("<%= user['email'] %>")
+user.addProperty(email)
+user.save()
+<% end %>

--- a/test/integration/jenkins_script/serverspec/assert_executed_spec.rb
+++ b/test/integration/jenkins_script/serverspec/assert_executed_spec.rb
@@ -5,3 +5,15 @@ describe jenkins_user('yzl') do
   it { should have_full_name('Yvonne Lam') }
   it { should have_email('yzl@chef.io') }
 end
+
+describe jenkins_user('badger') do
+  it { should be_a_jenkins_user }
+  it { should have_full_name('Badger Badger') }
+  it { should have_email('badger@chef.io') }
+end
+
+describe jenkins_user('foo') do
+  it { should be_a_jenkins_user }
+  it { should have_full_name('Foo Foo') }
+  it { should have_email('foo@chef.io') }
+end


### PR DESCRIPTION
### Description

Currently the `jenkins_script` resource uses heredoc for inline groovy scripts. This is sometimes not what we want and being able to template a groovy file from an erb template and point to the `groovy_path` is useful. Have made sure this maintains backwards compatibility and have added tests.

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
