### PR TITLE
Fix permissions on /var/xxx/jenkins folders for Debian/CentOS

### DIFF
--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -55,6 +55,24 @@ directory node['jenkins']['master']['home'] do
   recursive true
 end
 
+# Create the log directory
+directory node['jenkins']['master']['log_directory'] do
+  owner     node['jenkins']['master']['user']
+  group     node['jenkins']['master']['group']
+  mode      '0755'
+  recursive true
+end
+
+# Create/fix permissions on supplemental directories
+%w(cache lib run).each do |folder|
+  directory "/var/#{folder}/jenkins" do
+    owner node['jenkins']['master']['user']
+    group node['jenkins']['master']['group']
+    mode '0755'
+    action :create
+  end
+end
+
 case node['platform_family']
 when 'debian'
   template '/etc/default/jenkins' do


### PR DESCRIPTION
Signed-off-by: Denis Shvedchenko <dshvedchenko@sphereinc.com>

### Description

Respects  permission for  user node['jenkins']['master']['user']
- /var/lib/jenkins
- /var/run/jenkins
- /var/cache/jenkins

### Issues Resolved

https://github.com/chef-cookbooks/jenkins/issues/578

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
