### PR TITLE
Update Changelog.md to to fix broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 This file is used to list changes made in each version of the jenkins cookbook.
 
-## [5.0.0](https://github.com/chef-cookbooks/jenkins/tree/5.0.0) (2017-03-08)
-[Full Changelog](https://github.com/chef-cookbooks/jenkins/compare/v4.2.1...5.0.0)
+## [5.0.0](https://github.com/chef-cookbooks/jenkins/tree/v5.0.0) (2017-03-08)
+[Full Changelog](https://github.com/chef-cookbooks/jenkins/compare/v4.2.1...v5.0.0)
 
 **Improvements**
 - Add support for 2.x ([daften](https://github.com/daften))


### PR DESCRIPTION
### Remove bad links

These links did not resolve to anything useful. 

* This returns a 404, https://github.com/chef-cookbooks/jenkins/tree/5.0.0
* This does a compare, but since this is merged there's nothing to view, https://github.com/chef-cookbooks/jenkins/compare/v4.2.1...5.0.0

Signed-off-by: Gregory Kman <gregorykman@gmail.com>