### PR TITLE
Allow Jenkins to read system environment variables

### DIFF
--- a/templates/default/sv-jenkins-run.erb
+++ b/templates/default/sv-jenkins-run.erb
@@ -5,6 +5,7 @@
 # Do NOT modify this file by hand.
 #
 
+[ -r /etc/profile ] && . /etc/profile
 
 <% groups = ([node['jenkins']['master']['user']] + node['jenkins']['master']['runit']['groups']).join(':') %>
 exec 2>&1


### PR DESCRIPTION
### Description

Without the proposed change, we cannot read user-defined variables. This is particularly useful to define passwords (/etc/profile.d/mypasswords.sh), for example, and read them on jenkins jobs.

### Issues Resolved

I cannot read variables defined on /etc/profile.d.