### PR TITLE
Remove resource cloning in delete test.

### DIFF
--- a/test/fixtures/cookbooks/jenkins_user/recipes/delete.rb
+++ b/test/fixtures/cookbooks/jenkins_user/recipes/delete.rb
@@ -1,11 +1,8 @@
 include_recipe 'jenkins_server_wrapper::default'
 
-# Create a simple user
-jenkins_user 'sethvargo'
-
-# Delete an existing user
+# Create and Delete an existing user
 jenkins_user 'sethvargo' do
-  action :delete
+  action [:create, :delete]
 end
 
 # Delete a non-existent user


### PR DESCRIPTION
### Description

Remove resource cloning in delete test cookbook.

### Issues Resolved

Chef 13 maintenance.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
