### PR TITLE
Fix execution of jenkins commands when authorization is not enabled yet

### DIFF
--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -98,7 +98,7 @@ module Jenkins
         # These types of exceptions are commonly thrown the first time a Chef run
         # enables authentication on the Jenkins master. This should also fix some
         # cases of JENKINS-22346.
-        if ((exitstatus == 255) && (stderr =~ /^Authentication failed\. No private key accepted\.$/)) ||
+        if ((exitstatus == 255) && (stderr =~ /.*?Authentication failed\. No private key accepted\.$/)) ||
            ((exitstatus == 255) && (stderr =~ /^java\.io\.EOFException/)) ||
            ((exitstatus == 1) && (stderr =~ /^Exception in thread "main" java\.io\.EOFException/))
           command.reject! { |c| c =~ /-i/ }


### PR DESCRIPTION
Signed-off-by: Denis Shvedchenko <dshvedchenko@sphereinc.com>

### Description

Fixed execution of command when authorization are not enabled yet, first met on 2.46.2 Jenkins LTS

### Issues Resolved

#599 Partial resolve

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
