### PR TITLE
loosen regex to fix issue 609

### DIFF
--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -98,9 +98,9 @@ module Jenkins
         # These types of exceptions are commonly thrown the first time a Chef run
         # enables authentication on the Jenkins master. This should also fix some
         # cases of JENKINS-22346.
-        if ((exitstatus == 255) && (stderr =~ /^Authentication failed\. No private key accepted\.$/)) ||
-           ((exitstatus == 255) && (stderr =~ /^java\.io\.EOFException/)) ||
-           ((exitstatus == 1) && (stderr =~ /^Exception in thread "main" java\.io\.EOFException/))
+        if ((exitstatus == 255) && (stderr =~ /Authentication failed\. No private key accepted\./)) ||
+           ((exitstatus == 255) && (stderr =~ /java\.io\.EOFException/)) ||
+           ((exitstatus == 1) && (stderr =~ /Exception in thread "main" java\.io\.EOFException/))
           command.reject! { |c| c =~ /-i/ }
           retry
         elsif (exitstatus == 255) && (stderr =~ /^"--username" is not a valid option/)


### PR DESCRIPTION
### Description

Loosen regex to fall back to anonymous authentication after a failure

### Issues Resolved
https://github.com/chef-cookbooks/jenkins/issues/609

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
