### PR TITLE
plugin install needs file:// URI

### DIFF
--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -314,7 +314,7 @@ EOH
       # Jenkins that prevents Jenkins from following 302 redirects, so we
       # use Chef to download the plugin and then use Jenkins to install it.
       # It's a bit backwards, but so is Jenkins.
-      executor.execute!('install-plugin', escape(plugin.path), '-name', escape(plugin_name), opts[:cli_opts])
+      executor.execute!('install-plugin', escape('file://' + plugin.path), '-name', escape(plugin_name), opts[:cli_opts])
     end
 
     #


### PR DESCRIPTION
### Description

Fixes the plugin install command, which needs the file:// URI prepended to locate files on the local system.

### Issues Resolved
https://github.com/chef-cookbooks/jenkins/issues/614


### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ N/A ]New functionality includes testing.
- [N/A ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
