### PR TITLE
Add attribute for update-center channel

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -78,6 +78,7 @@ suites:
       jenkins:
         master:
           channel: current
+          update_center_channel: current
           install_method: package
   - name: smoke_war_stable
     run_list: jenkins_server_wrapper::default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -45,6 +45,7 @@ suites:
       jenkins:
         master:
           channel: current
+          update_center_channel: current
           install_method: package
   - name: smoke_war_stable
     run_list: jenkins_server_wrapper::default

--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -48,7 +48,8 @@ default['jenkins']['master'].tap do |master|
   # The "channel" to use, default is stable
   # Alternatively: "current" for install method package and "latest" for install method war
   #
-  master['channel'] = 'stable'
+  master['channel']               = 'stable'
+  master['update_center_channel'] = 'stable'
 
   #
   # The mirror to download the Jenkins war file. This attribute is only used

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -470,7 +470,7 @@ EOH
     #
     def ensure_update_center_present!
       node.run_state[:jenkins_update_center_present] ||= begin # ~FC001
-        source = uri_join(node['jenkins']['master']['mirror'], node['jenkins']['master']['channel'], 'update-center.json')
+        source = uri_join(node['jenkins']['master']['mirror'], node['jenkins']['master']['update_center_channel'], 'update-center.json')
         remote_file = Chef::Resource::RemoteFile.new(update_center_json, run_context)
         remote_file.source(source)
         remote_file.backup(false)


### PR DESCRIPTION
### Description

Ubuntu14.04,  Jenkins stable version is `2.46.3`. 
But, update-center redirect to version `1.580`, so I can't install plugin what required higher 1.6.
( like [display-url-api](https://wiki.jenkins-ci.org/display/JENKINS/Display+URL+API+Plugin) )

changed to define attribute for update-center channel.

```
vagrant@ubuntu-1404:~$ apt-cache policy jenkins
jenkins:
  Installed: 2.46.3
  Candidate: 2.46.3
  Version table:
 *** 2.46.3 0
        500 https://pkg.jenkins.io/debian-stable/ binary/ Packages
        100 /var/lib/dpkg/status
vagrant@ubuntu-1404:~$ curl -I https://updates.jenkins.io/stable/update-center.json
HTTP/1.1 301 Moved Permanently
Date: Thu, 08 Jun 2017 02:21:34 GMT
Server: Apache/2.4.7 (Ubuntu)
Location: https://updates.jenkins.io/stable-1.580/update-center.json
Content-Type: text/html; charset=iso-8859-1

vagrant@ubuntu-1404:~$
```

### Issues Resolved

None

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
