### PR TITLE
Fix some typos in the credentials area

### DIFF
--- a/libraries/credentials.rb
+++ b/libraries/credentials.rb
@@ -154,7 +154,7 @@ class Chef
 
     #
     # Returns a Groovy snippet that creates an instance of the
-    # credentail's implementation. The credentials instance should be
+    # credential's implementation. The credentials instance should be
     # set to a Groovy variable named `credentials`.
     #
     # @abstract
@@ -197,7 +197,7 @@ class Chef
     end
 
     #
-    # Maps a credentails's resource attribute name to the equivalent
+    # Maps a credentials's resource attribute name to the equivalent
     # property in the Groovy representation. This mapping is useful in
     # Ruby/Groovy serialization/deserialization.
     #

--- a/libraries/credentials_user.rb
+++ b/libraries/credentials_user.rb
@@ -37,7 +37,7 @@ class Chef
     include Jenkins::Helper
 
     def load_current_resource
-      @current_resource ||= Resource::JenkinsCredentialsUser.new(new_resource.name)
+      @current_resource ||= Resource::JenkinsUserCredentials.new(new_resource.name)
 
       super
 


### PR DESCRIPTION
Obvious fix.

Signed-off-by: Olivier Tharan <o.tharan@criteo.com>

### Description

This fixes a typo in a class name that I am not sure how it was not caught before, during usage of the resource.

### Issues Resolved


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
