### PR TITLE
Modified case statements to support package installation on Amazon Linux

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -33,7 +33,7 @@ default['jenkins']['master'].tap do |master|
   #   node.normal['jenkins']['master']['install_method'] = 'war'
   #
   master['install_method'] = case node['platform_family']
-                             when 'debian', 'rhel' then 'package'
+                             when 'debian', 'rhel', 'amazon' then 'package'
                              else 'war'
                              end
 
@@ -228,11 +228,11 @@ default['jenkins']['master'].tap do |master|
     case [node['platform_family'], node['jenkins']['master']['channel']]
     when %w(debian stable)
       ['https://pkg.jenkins.io/debian-stable', 'https://pkg.jenkins.io/debian-stable/jenkins.io.key']
-    when %w(rhel stable)
+    when %w(rhel stable), %w(amazon stable)
       ['https://pkg.jenkins.io/redhat-stable', 'https://pkg.jenkins.io/redhat-stable/jenkins.io.key']
     when %w(debian current)
       ['https://pkg.jenkins.io/debian', 'https://pkg.jenkins.io/debian/jenkins.io.key']
-    when %w(rhel current)
+    when %w(rhel current), %w(amazon current)
       ['https://pkg.jenkins.io/redhat', 'https://pkg.jenkins.io/redhat/jenkins.io.key']
     end
 

--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -37,7 +37,7 @@ when 'debian'
   dpkg_autostart 'jenkins' do
     allow false
   end
-when 'rhel'
+when 'rhel', 'amazon'
   yum_repository 'jenkins-ci' do
     baseurl node['jenkins']['master']['repository']
     gpgkey  node['jenkins']['master']['repository_key']
@@ -62,7 +62,7 @@ when 'debian'
     mode     '0644'
     notifies :restart, 'service[jenkins]', :immediately
   end
-when 'rhel'
+when 'rhel', 'amazon'
   template '/etc/sysconfig/jenkins' do
     source   'jenkins-config-rhel.erb'
     mode     '0644'

--- a/recipes/java.rb
+++ b/recipes/java.rb
@@ -42,7 +42,7 @@ when 'debian'
   else
     package 'openjdk-7-jdk'
   end
-when 'rhel'
+when 'rhel', 'amazon'
   package 'java-1.8.0-openjdk'
 else
   raise "`#{node['platform_family']}' is not supported!"

--- a/spec/recipes/java_spec.rb
+++ b/spec/recipes/java_spec.rb
@@ -45,6 +45,17 @@ describe 'jenkins::java' do
     end
   end
 
+  context 'on Amazon Linux 2017.03' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'amazon', version: '2017.03')
+                          .converge(described_recipe)
+    end
+
+    it 'installs java-1.8.0-openjdk' do
+      expect(chef_run).to install_package('java-1.8.0-openjdk')
+    end
+  end
+
   context 'on an unsupported platform' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'mac_os_x', version: '10.12')


### PR DESCRIPTION
### Description

This change allows the installation of the jenkins package from a yum repository on Amazon Linux instances. This is necessary as Amazon Linux is not considered to be in the `rhel` family, but supports `rpm` package installation via `yum`.

~I've ignored FC024 from Foodcritic as I believe that adding additional explicit platform families outside of `amazon` and `rhel` is outside of the scope of this change, and would unnecessarily increase complexity.~ Not required in Foodcritic >= 10.3.0

### Issues Resolved

None known

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
