### PR TITLE
Changes endpoint for 'wait_until_ready' helper

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -425,7 +425,7 @@ EOH
     def wait_until_ready!
       Timeout.timeout(timeout, JenkinsTimeout) do
         begin
-          open(endpoint)
+          open("#{endpoint}/whoAmI/")
         rescue SocketError,
                Errno::ECONNREFUSED,
                Errno::ECONNRESET,


### PR DESCRIPTION
Signed-off-by: Bastian Roden <broden@schubergphilis.com>

### Description
This allows the ready check (to see if Jenkins is ready after a restart)
to work even if an authentication method is enabled by polling an
"Unprotected URL" (built-in URLs that are excluded from authentication)

### Issues Resolved

https://github.com/chef-cookbooks/jenkins/issues/641

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
