### PR TITLE
Fix permissions for plugin files downloaded from update center

### DIFF
--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -307,6 +307,8 @@ EOH
       path   = ::File.join(Chef::Config[:file_cache_path], "#{plugin_name}-#{version}.plugin")
       plugin = Chef::Resource::RemoteFile.new(path, run_context)
       plugin.source(source_url)
+      plugin.owner('jenkins')
+      plugin.group('jenkins')
       plugin.backup(false)
       plugin.run_action(:create)
 


### PR DESCRIPTION
### Description
Fixes permissions on plugin files retrieved from Jenkin's update center so that they can be executed remotely for installing. Temporary files' owner and group are now set to `jenkins`.

### Issues Resolved

#644

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
