### PR TITLE
Wait for Jenkins in case of EADDRNOTAVAIL

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -430,6 +430,7 @@ EOH
                Errno::ECONNREFUSED,
                Errno::ECONNRESET,
                Errno::ENETUNREACH,
+               Errno::EADDRNOTAVAIL,
                Timeout::Error,
                OpenURI::HTTPError => e
           # If authentication has been enabled, the server will return an HTTP


### PR DESCRIPTION
### Description

[`wait_until_ready!`](https://github.com/chef-cookbooks/jenkins/blob/d9a75da24286ffbcc056af5fffa8fa54f5838dcf/libraries/_helper.rb#L425-L447) retries connecting to the Jenkins port in case of many different exceptions being returned from the `open()` call.

In my case, I'm currently hitting `Errno::EADDRNOTAVAIL` for the time when Jetty is down and _not_ returning 503s. This exception will currently propagated to the caller and provisioning fails.

Thus add `Errno::EADDRNOTAVAIL` to the list of expected exceptions when connecting to Jenkins.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
