### PR TITLE
Allow custom runit service name

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -201,6 +201,11 @@ default['jenkins']['master'].tap do |master|
   master['maxopenfiles'] = 8192
 
   #
+  # The name used for Jenkins runit service
+  #
+  master['runit']['service'] = 'jenkins'
+
+  #
   # The groups of user under which Jenkins is running. Works for runit only.
   #
   master['runit']['groups'] = [node['jenkins']['master']['group']]

--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -61,12 +61,16 @@ remote_file File.join(node['jenkins']['master']['home'], 'jenkins.war') do
   checksum node['jenkins']['master']['checksum'] if node['jenkins']['master']['checksum']
   owner    node['jenkins']['master']['user']
   group    node['jenkins']['master']['group']
-  notifies :restart, 'runit_service[jenkins]'
+  notifies :restart, "runit_service[#{node['jenkins']['master']['runit']['service']}]"
 end
 
 Chef::Log.warn('Here we go with the runit service')
 
 # Create runit service
-runit_service 'jenkins' do
+runit_service node['jenkins']['master']['runit']['service'] do
+  run_template_name 'jenkins'
+  log_template_name 'jenkins'
+  check_script_template_name 'jenkins'
+  finish_script_template_name 'jenkins'
   sv_timeout node['jenkins']['master']['runit']['sv_timeout']
 end

--- a/spec/recipes/master_spec.rb
+++ b/spec/recipes/master_spec.rb
@@ -6,14 +6,16 @@ describe 'jenkins::_master_war' do
     let(:log_directory) { '/opt/bacon/log' }
     let(:user)          { 'bacon' }
     let(:group)         { 'meats' }
+    let(:service_name)  { 'bacon' }
 
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.normal['jenkins']['master']['home']           = home
-        node.normal['jenkins']['master']['log_directory']  = log_directory
-        node.normal['jenkins']['master']['user']           = user
-        node.normal['jenkins']['master']['group']          = group
-        node.normal['jenkins']['master']['install_method'] = 'war'
+        node.normal['jenkins']['master']['home']             = home
+        node.normal['jenkins']['master']['log_directory']    = log_directory
+        node.normal['jenkins']['master']['user']             = user
+        node.normal['jenkins']['master']['group']            = group
+        node.normal['jenkins']['master']['install_method']   = 'war'
+        node.normal['jenkins']['master']['runit']['service'] = service_name
       end.converge(described_recipe)
     end
 
@@ -45,6 +47,10 @@ describe 'jenkins::_master_war' do
         .with_group(group)
         .with_mode('0755')
         .with_recursive(true)
+    end
+
+    it 'creates the named service' do
+      expect(chef_run).to enable_runit_service(service_name)
     end
   end
 


### PR DESCRIPTION
Added a new attribute for master ['runit']['service'] to allow service name customization.
Updated runit_service definition to manage a named service using jenkins templates.

### Description
This change creates a runit service using name defined by calling cookbook.

### Issues Resolved
https://github.com/chef-cookbooks/jenkins/issues/649

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <>
