### PR TITLE
Change groovy scripts to use stdin instead of file. Fixes #620

### DIFF
--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -134,12 +134,7 @@ module Jenkins
     #   the standard out from the command
     #
     def groovy!(script)
-      file = Tempfile.new('groovy')
-      file.write script
-      file.flush
-      execute!("groovy #{file.path}")
-    ensure
-      file.close! if file
+      execute!("groovy =", {input: script})
     end
 
     #
@@ -148,12 +143,7 @@ module Jenkins
     # @see groovy!
     #
     def groovy(script)
-      file = Tempfile.new('groovy')
-      file.write script
-      file.flush
-      execute("groovy #{file.path}")
-    ensure
-      file.close! if file
+      execute("groovy =", {input: script})
     end
 
     private

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -134,7 +134,7 @@ module Jenkins
     #   the standard out from the command
     #
     def groovy!(script)
-      execute!("groovy =", {input: script})
+      execute!('groovy =', input: script)
     end
 
     #
@@ -143,7 +143,7 @@ module Jenkins
     # @see groovy!
     #
     def groovy(script)
-      execute("groovy =", {input: script})
+      execute('groovy =', input: script)
     end
 
     private

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -173,7 +173,7 @@ describe Jenkins::Executor do
 
     it 'calls execute!' do
       expect(subject).to receive(:execute!)
-        .with(/^groovy \S+/)
+        .with('groovy =', input: 'script')
       subject.groovy('script')
     end
   end
@@ -183,7 +183,7 @@ describe Jenkins::Executor do
 
     it 'calls execute' do
       expect(subject).to receive(:execute)
-        .with(/^groovy \S+/)
+        .with('groovy =', input: 'script')
       subject.groovy('script')
     end
   end


### PR DESCRIPTION
### Description

As suggested in https://issues.jenkins-ci.org/browse/JENKINS-41765 using groovy scripts requires piping in the script instead of passing path to file

### Issues Resolved

#620

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Didn't run testsuite. The changes feel trivial but might still break things. Works in my environment with Linux & Windows nodes
