### PR TITLE
Ensure that we only reject the '-i key' part of command execution

### DIFF
--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -101,7 +101,7 @@ module Jenkins
         if ((exitstatus == 255) && (stderr =~ /.*?Authentication failed\. No private key accepted\.$/)) ||
            ((exitstatus == 255) && (stderr =~ /^java\.io\.EOFException/)) ||
            ((exitstatus == 1) && (stderr =~ /^Exception in thread "main" java\.io\.EOFException/))
-          command.reject! { |c| c =~ /-i/ }
+          command.reject! { |c| c =~ /^-i / }
           retry
         elsif (exitstatus == 255) && (stderr =~ /^"--username" is not a valid option/)
           command.reject! { |c| c =~ /--username|--password/ }


### PR DESCRIPTION
Ensure that we only reject the '-i key' part of command execution and not parts that contain '-i' in larger strings.

We ran into the case where if node['jenkins']['master']['prefix'] contains '-i' the -s (server address) array element was removed.

For example:

node['jenkins']['master']['prefix'] = '/this-is-my-jenkins'
generates the command
java, -jar /.../jenkins-cli.jar -s http://127.0.0.1:8080/this-is-my-jenkins/ -i /.../jenkins-key install-plugin /.../ace-editor-....plugin -name ace-editor

This fails because we have not yet installed and configured the ldap plugin.

The retry then tries
java, -jar /.../jenkins-cli.jar install-plugin /.../ace-editor-....plugin -name ace-editor

because /-i/ matches against 'this-is-my-key' and removes the '-s ...' element.

Obvious fix.