### PR TITLE
Plugins: User & Group should be read from attributes

### DIFF
--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -307,8 +307,8 @@ EOH
       path   = ::File.join(Chef::Config[:file_cache_path], "#{plugin_name}-#{version}.plugin")
       plugin = Chef::Resource::RemoteFile.new(path, run_context)
       plugin.source(source_url)
-      plugin.owner('jenkins')
-      plugin.group('jenkins')
+      plugin.owner(node['jenkins']['master']['user'])
+      plugin.group(node['jenkins']['master']['group'])
       plugin.backup(false)
       plugin.run_action(:create)
 


### PR DESCRIPTION
Removed hardcoding of 'jenkins' with the value that is set in attributes while installing plugins.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
