### PR TITLE
Fix #670: Support old slave_jar_resource function still in use in windows slave…

### DIFF
--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -156,7 +156,7 @@ class Chef
 
     def do_create
       # Preserve some labels...
-      merge_preserved_lables!
+      merge_preserved_labels!
       if current_resource.exists? && correct_config?
         Chef::Log.info("#{new_resource} exists - skipping")
       else

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -150,7 +150,13 @@ class Chef
       do_create
     end
 
+    def merge_preserved_labels!
+      new_resource.labels |= current_resource.labels.select{ |i| i[/^prsrv_/] }
+    end
+
     def do_create
+      # Preserve some labels...
+      merge_preserved_lables!
       if current_resource.exists? && correct_config?
         Chef::Log.info("#{new_resource} exists - skipping")
       else

--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -98,6 +98,18 @@ class Chef
 
     # Embedded Resources
 
+    # Due to a convention change, resources created in the parent need to be
+    # repeated in the convention used here
+    def slave_jar_resource
+        return @slave_jar_resource if @slave_jar_resource
+        @slave_jar_resource = Chef::Resource::RemoteFile.new(slave_jar, run_context)
+        @slave_jar_resource.source(slave_jar_url)
+        @slave_jar_resource.backup(false)
+        @slave_jar_resource.mode('0777')
+        @slave_jar_resource.atomic_update(false)
+        @slave_jar_resource
+    end
+
     # Creates a `directory` resource that represents the directory
     # specified the `remote_fs` attribute. The caller will need to call
     # `run_action` on the resource.

--- a/templates/sv-jenkins-slave-run.erb
+++ b/templates/sv-jenkins-slave-run.erb
@@ -5,9 +5,12 @@
 # Do NOT modify this file by hand.
 #
 
+# Get the groups of the service user:
+SUPL_GRPS=`id -nG <%= @options[:user] %>|sed 's/ /:/g'`
+
 exec 2>&1
 cd <%= @options[:remote_fs] %>
-exec chpst -u <%= @options[:user] %> \
+exec chpst -u <%= @options[:user] %>:$SUPL_GRPS \
   env HOME=<%= @options[:remote_fs] %> \
   JENKINS_HOME=<%= @options[:remote_fs] %> \
   <%= @options[:java_bin] %> \


### PR DESCRIPTION
… provider

### Description

Fix #670: Support old slave_jar_resource function still in use in windows slave

### Issues Resolved

#670 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
