### PR TITLE
Fix plugin version parsing

### DIFF
--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -437,7 +437,8 @@ EOH
     # @return [String]
     #
     def plugin_version(version)
-      Gem::Version.new(version)
+      gem_version = Gem::Version.new(version)
+      gem_version.prerelease? ? version : gem_version
     rescue ArgumentError
       version
     end

--- a/test/fixtures/cookbooks/jenkins_plugin/recipes/install.rb
+++ b/test/fixtures/cookbooks/jenkins_plugin/recipes/install.rb
@@ -8,6 +8,11 @@ jenkins_plugin 'disk-usage' do
   version '0.23'
 end
 
+# Test installing a specific version with abnormal versioning
+jenkins_plugin 'apache-httpcomponents-client-4-api' do
+  version '4.5.3-2.0'
+end
+
 # Test installing from a URL
 jenkins_plugin 'copy-to-slave' do
   source 'http://mirror.xmission.com/jenkins/plugins/copy-to-slave/1.4.3/copy-to-slave.hpi'

--- a/test/integration/jenkins_plugin_install/serverspec/assert_installed_spec.rb
+++ b/test/integration/jenkins_plugin_install/serverspec/assert_installed_spec.rb
@@ -14,6 +14,11 @@ describe jenkins_plugin('copy-to-slave') do
   it { should have_version('1.4.3') }
 end
 
+describe jenkins_plugin('apache-httpcomponents-client-4-api') do
+  it { should be_a_jenkins_plugin }
+  it { should have_version('4.5.3-2.0') }
+end
+
 describe jenkins_plugin('github-oauth') do
   it { should be_a_jenkins_plugin }
 end


### PR DESCRIPTION
### Description

Several Jenkins plugins use versioning schemes that do not match with standard gem versioning. In these cases, version strings will actually parse (thus the [rescue](https://github.com/chef-cookbooks/jenkins/blob/master/libraries/plugin.rb#L441) is not called) if they would be considered a ["prerelease" gem](http://guides.rubygems.org/patterns/#prerelease-gems).

For example, `Gem::Version.new('4.5.3-2.0')` becomes `4.5.3.pre.2.0`. This causes Jenkins plugins that match this type of error to always install the latest version, as this [substitution](https://github.com/chef-cookbooks/jenkins/blob/master/libraries/plugin.rb#L288) results in a noop. See included test case for an example that currently fails against master.

This change throws out any parsed Gem::Version instances that would be considered a "prerelease" and uses string based version matching.

### Issues Resolved
GH-676

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
