### PR TITLE
Allow optional checksum property for plugin install from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,9 @@ end
 # Install a plugin from a given hpi (or jpi)
 jenkins_plugin 'greenballs' do
   source 'http://updates.jenkins-ci.org/download/plugins/greenballs/1.10/greenballs.hpi'
+  # Optional: The SHA-256 checksum of the pointed hpi (or jpi)
+  # See https://docs.chef.io/resource_remote_file.html#checksum
+  checksum '2a7395269bd736d3baa685b7d205a0ceef3a99bab98e5363ae785dbe30729ac2'
 end
 
 # Don't install a plugins dependencies

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -47,6 +47,8 @@ class Chef
     attribute :install_deps,
               kind_of: [TrueClass, FalseClass],
               default: true
+    attribute :checksum,
+              kind_of: String
     attribute :options,
               kind_of: String
 
@@ -118,14 +120,16 @@ EOH
             new_resource.source,
             new_resource.name,
             nil,
-            cli_opts: new_resource.options
+            cli_opts: new_resource.options,
+            checksum: new_resource.checksum
           )
         else
           install_plugin_from_update_center(
             new_resource.name,
             new_resource.version,
             cli_opts: new_resource.options,
-            install_deps: new_resource.install_deps
+            install_deps: new_resource.install_deps,
+            checksum: new_resource.checksum
           )
         end
       end
@@ -259,6 +263,7 @@ EOH
     # @param [Hash] opts the options install plugin with
     # @option opts [Boolean] :cli_opts additional flags to pass the jenkins cli command
     # @option opts [Boolean] :install_deps indicates a plugins dependencies should be installed
+    # @option opts [String] :checksum indicates the checksum of the *.hpi/*.jpi to install
     #
     def install_plugin_from_update_center(plugin_name, plugin_version, opts = {})
       remote_plugin_data = plugin_universe[plugin_name]
@@ -299,6 +304,7 @@ EOH
     # @param [Hash] opts the options install plugin with
     # @option opts [Boolean] :cli_opts additional flags to pass the jenkins cli command
     # @option opts [Boolean] :install_deps indicates a plugins dependencies should be installed
+    # @option opts [String] :checksum indicates the checksum of the *.hpi/*.jpi to install
     #
     def install_plugin_from_url(source_url, plugin_name, plugin_version = nil, opts = {})
       version = plugin_version || Digest::MD5.hexdigest(source_url)
@@ -311,6 +317,7 @@ EOH
       plugin.owner(node['jenkins']['master']['user'])
       plugin.group(node['jenkins']['master']['group'])
       plugin.backup(false)
+      plugin.checksum(opts[:checksum]) if opts[:checksum]
       plugin.run_action(:create)
 
       # Install the plugin from our local cache on disk. There is a bug in

--- a/test/fixtures/cookbooks/jenkins_plugin/recipes/install.rb
+++ b/test/fixtures/cookbooks/jenkins_plugin/recipes/install.rb
@@ -18,6 +18,18 @@ jenkins_plugin 'copy-to-slave' do
   source 'http://mirror.xmission.com/jenkins/plugins/copy-to-slave/1.4.3/copy-to-slave.hpi'
 end
 
+# Test installing from a URL with checksum
+jenkins_plugin 'ansicolor' do
+  source 'http://mirror.xmission.com/jenkins/plugins/ansicolor/0.5.2/ansicolor.hpi'
+  checksum '726c651a3ac8d080ff4aa5b962dd8b264801b8a3fde027da07fa1be30c709b31'
+end
+
+# Test installing from a URL with invalid checksum fails
+jenkins_plugin 'timestamper' do
+  source 'http://mirror.xmission.com/jenkins/plugins/timestamper/1.8.10/timestamper.hpi'
+  checksum 'invalid'
+end
+
 # Install a plugin with many deps
 jenkins_plugin 'github-oauth' do
   install_deps true

--- a/test/integration/jenkins_plugin_install/serverspec/assert_installed_spec.rb
+++ b/test/integration/jenkins_plugin_install/serverspec/assert_installed_spec.rb
@@ -14,6 +14,15 @@ describe jenkins_plugin('copy-to-slave') do
   it { should have_version('1.4.3') }
 end
 
+describe jenkins_plugin('ansicolor') do
+  it { should be_a_jenkins_plugin }
+  it { should have_version('0.5.2') }
+end
+
+describe jenkins_plugin('timestamper') do
+  it { should_not be_a_jenkins_plugin }
+end
+
 describe jenkins_plugin('apache-httpcomponents-client-4-api') do
   it { should be_a_jenkins_plugin }
   it { should have_version('4.5.3-2.0') }


### PR DESCRIPTION

### Description

Add an optional checksum attribute to the plugins installer that will be passed to the Chef::Resource::RemoteFile when installing a plugin form url.

### Issues Resolved

We can now specify a checksum in addition to the source url when installing plugins from url.
This will enforce the authenticity and trustfulness of the linked source hpi (or jpi) file by preventing spoofing, malicious activity, broken download, and so on.
Also prevent the chef-client from re-downloading the hpi (or jpi) file if already present on the node. (see https://docs.chef.io/resource_remote_file.html#prevent-re-downloads)

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
