### PR TITLE
Fix cloning resources attributes for/var/lib/jenkins

### DIFF
--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -65,7 +65,8 @@ end
 
 # Create/fix permissions on supplemental directories
 %w(cache lib run).each do |folder|
-  directory "/var/#{folder}/jenkins" do
+  directory "fix permissions for /var/#{folder}/jenkins" do
+    path "/var/#{folder}/jenkins"
     owner node['jenkins']['master']['user']
     group node['jenkins']['master']['group']
     mode '0755'


### PR DESCRIPTION
### Description
Fix:
```
Deprecated features used!
         Cloning resource attributes for directory[/var/lib/jenkins]
from prior resource
       Previous directory[/var/lib/jenkins]:
/tmp/kitchen/cache/cookbooks/jenkins/recipes/_master_package.rb:51:in
`from_file'
       Current  directory[/var/lib/jenkins]:
/tmp/kitchen/cache/cookbooks/jenkins/recipes/_master_package.rb:68:in
`block in from_file' at 1 location:
           -
/tmp/kitchen/cache/cookbooks/jenkins/recipes/_master_package.rb:68:in
`block in from_file'
          See https://docs.chef.io/deprecations_resource_cloning.html
for further details.
```

### Issues Resolved
https://github.com/chef-cookbooks/jenkins/issues/679 - master_package.rb contains cloned directory resource

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
