### PR TITLE
jenkins-cli uses -auth option instead of --username, --password argum…

### DIFF
--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -77,9 +77,8 @@ module Jenkins
       command << %(-user "#{options[:cli_user]}")        if options[:cli_user]
       command << %(-i "#{options[:key]}")                if options[:key]
       command << %(-p #{uri_escape(options[:proxy])})    if options[:proxy]
+      command << %(-auth "#{options[:username]}":"#{options[:password]}") if options[:username] && options[:password]
       command.push(pieces)
-      command << %(--username "#{options[:username]}")   if options[:username]
-      command << %(--password "#{options[:password]}")   if options[:password]
 
       begin
         cmd = Mixlib::ShellOut.new(command.join(' '), command_options.merge(timeout: options[:timeout]))

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -50,20 +50,14 @@ describe Jenkins::Executor do
     end
 
     context 'when a :cli_username option is given' do
-      it 'adds --username option' do
-        subject.options[:username] = 'user'
-        command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --username "user")
-        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
-        subject.execute!('foo')
-      end
-    end
-
-    context 'when a :cli_password option is given' do
-      it 'adds --password option' do
-        subject.options[:password] = 'password'
-        command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --password "password")
-        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
-        subject.execute!('foo')
+      context 'when a :cli_password option is given' do
+        it 'adds -auth option' do
+          subject.options[:username] = 'user'
+          subject.options[:password] = 'password'
+          command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" -auth "user":"password" foo)
+          expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
+          subject.execute!('foo')
+        end
       end
     end
 


### PR DESCRIPTION
## Description

`--username` and `--password` arguments in  jenkins-cli are deprecated and replaced by `-auth` option.
With username/password you have to grant Overall/Read permission to anonymous user.

Examples:
`echo 'import hudson.model.User; println(User.current())' | java -jar ./jenkins-cli.jar -s http://localhost:8080 groovy = --username 'jenkins-user' --password 'mypassword'`

vs.

`echo 'import hudson.model.User; println(User.current())' | java -jar ./jenkins-cli.jar -s http://localhost:8080 -auth 'jenkins-user':'mypassword' groovy =`

## Tests

### ChefSpec

Passed without failures

### Travis.ci

Failed on:
- smoke-package-stable-centos-6
- smoke-war-stable-centos-6

Which is the same result as before commiting.

### Tests in own environment

Versions:
- Jenkins 2.138.1
- Active Directory plugin 2.8
- Matrix Authorization Strategy Plugin 2.3

Cookbook resources tested:
- jenkins_plugin
- jenkins_script

Tested with CLI protocol "http" and "remoting".