### PR TITLE
Mark windows template sensitive if setting password, remove default '…

### DIFF
--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -184,6 +184,7 @@ class Chef
       @slave_xml_resource = Chef::Resource::Template.new(slave_xml, run_context)
       @slave_xml_resource.cookbook('jenkins')
       @slave_xml_resource.source('jenkins-slave.xml.erb')
+      @slave_xml_resource.sensitive = true if new_resource.password
       @slave_xml_resource.variables(
         new_resource:  new_resource,
         endpoint:      endpoint,
@@ -263,7 +264,7 @@ class Chef
     end
 
     #
-    # Windows domain for the user or `.` if a domain is not set.
+    # Windows domain for the user or nil if there is no domain.
     #
     # @return [String]
     #
@@ -271,8 +272,6 @@ class Chef
       @user_domain ||= begin
         if (parts = new_resource.user.match(/(?<domain>.*)\\(?<account>.*)/))
           parts[:domain]
-        else
-          '.'
         end
       end
     end


### PR DESCRIPTION
Signed-off-by: Mendy Baitelman <mendy@baitelman.com>

### Description
Prevents windows password from being logged, ignores windows <domain> when using local user
### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
