### PR TITLE
jenkins-cli uses -auth instead of --username, --password

### DIFF
--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -77,9 +77,8 @@ module Jenkins
       command << %(-user "#{options[:cli_user]}")        if options[:cli_user]
       command << %(-i "#{options[:key]}")                if options[:key]
       command << %(-p #{uri_escape(options[:proxy])})    if options[:proxy]
+      command << %(-auth "#{options[:username]}":"#{options[:password]}") if options[:username] && options[:password]
       command.push(pieces)
-      command << %(--username "#{options[:username]}")   if options[:username]
-      command << %(--password "#{options[:password]}")   if options[:password]
 
       begin
         cmd = Mixlib::ShellOut.new(command.join(' '), command_options.merge(timeout: options[:timeout]))

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -50,20 +50,14 @@ describe Jenkins::Executor do
     end
 
     context 'when a :cli_username option is given' do
-      it 'adds --username option' do
-        subject.options[:username] = 'user'
-        command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --username "user")
-        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
-        subject.execute!('foo')
-      end
-    end
-
-    context 'when a :cli_password option is given' do
-      it 'adds --password option' do
-        subject.options[:password] = 'password'
-        command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --password "password")
-        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
-        subject.execute!('foo')
+      context 'when a :cli_password option is given' do
+        it 'adds -auth option' do
+          subject.options[:username] = 'user'
+          subject.options[:password] = 'password'
+          command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" -auth "user":"password" foo)
+          expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
+          subject.execute!('foo')
+        end
       end
     end
 


### PR DESCRIPTION
Signed-off-by: Jakob Pfeiffer <pgp-jkp@pfeiffer.ws>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
