### PR TITLE
update plugin resource to simply work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 addons:
   apt:
     sources:
-      - chef-current-bionic
+      - chef-current-xenial
     packages:
       - chefdk
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-current-bionic
     packages:
       - chefdk
 
@@ -21,12 +21,12 @@ env:
   # - INSTANCE=smoke-package-stable-centos-6 # terribly slow; takes more than 45 minutes
   - INSTANCE=smoke-package-stable-centos-7
   - INSTANCE=smoke-package-stable-debian-9
-  - INSTANCE=smoke-package-stable-ubuntu-1604
+  - INSTANCE=smoke-package-stable-ubuntu-1804
   # - INSTANCE=smoke-war-stable-centos-6 # terribly slow; takes more than 45 minutes
   - INSTANCE=smoke-war-stable-centos-7
   - INSTANCE=smoke-war-stable-debian-8
   - INSTANCE=smoke-war-stable-debian-9
-  - INSTANCE=smoke-war-stable-ubuntu-1604
+  - INSTANCE=smoke-war-stable-ubuntu-1804
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,13 @@ env:
   # - INSTANCE=smoke-package-stable-centos-6 # terribly slow; takes more than 45 minutes
   - INSTANCE=smoke-package-stable-centos-7
   - INSTANCE=smoke-package-stable-debian-9
+  - INSTANCE=smoke-package-stable-ubuntu-1604
   - INSTANCE=smoke-package-stable-ubuntu-1804
   # - INSTANCE=smoke-war-stable-centos-6 # terribly slow; takes more than 45 minutes
   - INSTANCE=smoke-war-stable-centos-7
   - INSTANCE=smoke-war-stable-debian-8
   - INSTANCE=smoke-war-stable-debian-9
+  - INSTANCE=smoke-war-stable-ubuntu-1604
   - INSTANCE=smoke-war-stable-ubuntu-1804
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 addons:
   apt:
     sources:
-      - chef-current-xenial
+      - chef-current-trusty
     packages:
       - chefdk
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installs and configures Jenkins CI master & node slaves. Resource providers to s
 
 ### Chef
 
-- Chef 12.14+
+- Chef 13.0+
 
 ### Cookbooks
 

--- a/README.md
+++ b/README.md
@@ -427,31 +427,23 @@ This resource manages Jenkins plugins.
 
 This uses the Jenkins CLI to install plugins. By default, it does a cold deploy, meaning the plugin is installed while Jenkins is still running. Some plugins may require you restart the Jenkins instance for their changed to take affect.
 
-- **A plugin's dependencies are also installed by default, this behavior can be disabled by setting the `install_deps` attribute to `false`.**
-- **This resource does not install plugin dependencies from a a given hpi/jpi URL - you must specify all plugin dependencies or Jenkins may not startup correctly!**
+- **This resource does not install plugin dependencies from a a given hpi/jpi URL or a specific version - you must specify all plugin dependencies or Jenkins may not startup correctly!**
 
 The `:install` action idempotently installs a Jenkins plugin on the current node. The name attribute corresponds to the name of the plugin on the Jenkins Update Center. You can also specify a particular version of the plugin to install. Finally, you can specify a full source URL or local path (on the node) to a plugin.
 
 ```ruby
-# Install the latest version of the greenballs plugin
+# Install the latest version of the greenballs plugin and all dependencies
 jenkins_plugin 'greenballs'
 
-# Install version 1.3 of the greenballs plugin
+# Install version 1.3 of the greenballs plugin and no dependencies
 jenkins_plugin 'greenballs' do
   version '1.3'
 end
 
-# Install a plugin from a given hpi (or jpi)
+# Install a plugin from a given hpi (or jpi) and no dependencies
 jenkins_plugin 'greenballs' do
   source 'http://updates.jenkins-ci.org/download/plugins/greenballs/1.10/greenballs.hpi'
 end
-
-# Don't install a plugins dependencies
-jenkins_plugin 'github-oauth' do
-  install_deps false
-end
-`
-`
 ```
 
 Depending on the plugin, you may need to restart the Jenkins instance for the plugin to take affect:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -19,10 +19,10 @@ platforms:
     image: dokken/amazonlinux
     pid_one_command: /sbin/init
 
-  - name: amazonlinux-2
-    driver:
-      image: dokken/amazonlinux-2
-      pid_one_command: /usr/lib/systemd/systemd
+- name: amazonlinux-2
+  driver:
+    image: dokken/amazonlinux-2
+    pid_one_command: /usr/lib/systemd/systemd
 
 - name: debian-8
   driver:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -19,6 +19,11 @@ platforms:
     image: dokken/amazonlinux
     pid_one_command: /sbin/init
 
+  - name: amazonlinux-2
+    driver:
+      image: dokken/amazonlinux-2
+      pid_one_command: /usr/lib/systemd/systemd
+
 - name: debian-8
   driver:
     image: dokken/debian-8
@@ -48,16 +53,16 @@ platforms:
     image: dokken/fedora-latest
     pid_one_command: /usr/lib/systemd/systemd
 
-- name: ubuntu-14.04
+- name: ubuntu-16.04
   driver:
-    image: dokken/ubuntu-14.04
+    image: dokken/ubuntu-16.04
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
-- name: ubuntu-16.04
+- name: ubuntu-18.04
   driver:
-    image: dokken/ubuntu-16.04
+    image: dokken/ubuntu-18.04
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,7 +1,7 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 'stable' %>
 
 transport:
   name: dokken

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -32,18 +32,24 @@ platforms:
   - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux
+  - name: amazonlinux-2
+    driver_config:
+      box: gbailey/amzn2
   - name: centos-6
   - name: centos-7
   - name: debian-8
   - name: debian-9
-  - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: ubuntu-18.04
   - name: windows-2012r2
     driver:
-      box: chef/windows-server-2012r2-standard # private box
+      box: tas50/windows_2012r2
   - name: windows-2016
     driver:
-      box: chef/windows-server-2016-standard # private box
+      box: tas50/windows_2016
+  - name: windows-2019
+    driver:
+      box: tas50/windows_2019
 
 verifier:
   name: inspec
@@ -55,9 +61,9 @@ suites:
   - name: smoke_package_stable
     run_list: jenkins_smoke::default
     excludes:
-      - ubuntu-14.04
       - windows-2012r2
       - windows-2016
+      - widnows-2019
 
   - name: smoke_package_current
     run_list: jenkins_smoke::default
@@ -66,9 +72,9 @@ suites:
         master:
           channel: current
     excludes:
-      - ubuntu-14.04
       - windows-2012r2
       - windows-2016
+      - windows-2019
 
   - name: smoke_war_stable
     run_list: jenkins_smoke::default
@@ -97,6 +103,7 @@ suites:
     excludes:
       - windows-2012r2
       - windows-2016
+      - windows-2019
 
   #
   # Proxy suites

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -63,7 +63,7 @@ suites:
     excludes:
       - windows-2012r2
       - windows-2016
-      - widnows-2019
+      - windows-2019
 
   - name: smoke_package_current
     run_list: jenkins_smoke::default

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -47,7 +47,7 @@ If this problem persists, check your Jenkins log files.
 
     # Matches Version 4 UUID per RFC 4122
     # Example: 38537014-ec66-49b5-aff2-aed1c19e2989
-    UUID_REGEX = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/.freeze unless defined?(UUID_REGEX)
+    UUID_REGEX = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/ unless defined?(UUID_REGEX)
 
     #
     # Helper method for creating an accessing a new {Jenkins::Executor} from

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -5,7 +5,7 @@
 # Author:: Seth Vargo <sethvargo@gmail.com>
 # Author:: Seth Chisamore <schisamo@chef.io>
 #
-# Copyright:: 2013-2017, Chef Software, Inc.
+# Copyright:: 2013-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,6 +44,9 @@ class Chef
               default: :latest
     attribute :source,
               kind_of: String
+    # TODO: Remove in next major version release
+    attribute :install_deps,
+              kind_of: [TrueClass, FalseClass]
     attribute :options,
               kind_of: String
 
@@ -64,7 +67,7 @@ end
 class Chef
   class Provider::JenkinsPlugin < Provider::LWRPBase
     provides :jenkins_plugin
-    use_inline_resources # ~FC113
+
     include Jenkins::Helper
 
     provides :jenkins_plugin
@@ -95,14 +98,13 @@ The Jenkins plugin `#{plugin}' is not installed. In order to #{action}
       @current_resource
     end
 
-    #
-    # This provider supports why-run mode.
-    #
-    def whyrun_supported?
-      true
-    end
-
     action :install do
+      # TODO: remove in next major version release
+      # Check for dependency property and give deprecation if used
+      if new_resource.install_deps
+        Chef::Log.warn('The install_deps property on the plugin provider is deprecated and not used. See Readme on how to install plugins with or without dependencies.')
+      end
+
       # This block stores the actual command to execute, since its the same
       # for upgrades and installs.
       install_block = proc do

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,4 +17,5 @@ depends 'dpkg_autostart'
 
 source_url 'https://github.com/chef-cookbooks/jenkins'
 issues_url 'https://github.com/chef-cookbooks/jenkins/issues'
-chef_version '>= 12.14'
+
+chef_version '>= 13.0'

--- a/test/fixtures/cookbooks/jenkins_plugin/recipes/install.rb
+++ b/test/fixtures/cookbooks/jenkins_plugin/recipes/install.rb
@@ -9,8 +9,8 @@ jenkins_plugin 'disk-usage' do
 end
 
 # Test installing a specific version with abnormal versioning
-jenkins_plugin 'apache-httpcomponents-client-4-api' do
-  version '4.5.3-2.0'
+jenkins_plugin 'nexus-jenkins-plugin' do
+  version '3.4.20190116-104331.e820fec'
 end
 
 # Test installing from a URL

--- a/test/fixtures/cookbooks/jenkins_plugin/recipes/install.rb
+++ b/test/fixtures/cookbooks/jenkins_plugin/recipes/install.rb
@@ -20,12 +20,7 @@ end
 
 # Install a plugin with many deps
 jenkins_plugin 'github-oauth' do
-  install_deps true
-end
-
-# Skip this plugins deps
-jenkins_plugin 'jquery-ui' do
-  install_deps false
+  install_deps true # TODO: remove with next major version release
 end
 
 # plugin to disable
@@ -46,7 +41,6 @@ end
 # Install with a wacky version number
 jenkins_plugin 'build-monitor-plugin' do
   version '1.6+build.135'
-  install_deps true
 
   action :install
   notifies :restart, 'service[jenkins]', :immediately

--- a/test/fixtures/cookbooks/jenkins_server_wrapper/recipes/default.rb
+++ b/test/fixtures/cookbooks/jenkins_server_wrapper/recipes/default.rb
@@ -10,6 +10,7 @@ jenkins_plugins = %w(
   ssh-slaves
   jdk-tool
   display-url-api
+  credentials
 )
 
 jenkins_plugins.each do |plugin|

--- a/test/integration/jenkins_smoke/controls/jenkins_plugin.rb
+++ b/test/integration/jenkins_smoke/controls/jenkins_plugin.rb
@@ -21,9 +21,9 @@ control 'jenkins_plugin-1.0' do
     its('version') { should eq '1.4.3' }
   end
 
-  describe jenkins_plugin('apache-httpcomponents-client-4-api') do
+  describe jenkins_plugin('nexus-jenkins-plugin') do
     it { should exist }
-    its('version') { should eq '4.5.3-2.0' }
+    its('version') { should eq '3.4.20190116-104331.e820fec' }
   end
 
   describe jenkins_plugin('github-oauth') do


### PR DESCRIPTION
update plugin resource to work with newer versions of Jenkins which f…ixes dependencies and removes need for additional plugin method

Signed-off-by: Corey Hemminger <hemminger@hotmail.com>

### Description

Makes plugin lwrp useful. For latest version of plugins it'll install plugin and all dependencies via the jenkings-cli.jar install-plugin command. Newer versions of Jenkins this works great. Removes the need to brute force dependency install that would loop through all dependencies and dependencies of dependencies even if they have repeating depencies and differing versions of dependencies. 

When specifying a source or specific version dependencies are not resolved and specific plugin is installed similar to old functionality based on url or file source on node.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
