### PR TITLE
[GH-685] - JNLP slave is configured to not use all the groups of the jenkins user

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,9 @@ jenkins_jnlp_slave 'smoke' do
   in_demand_delay 1
   idle_delay      3
   labels          ['runner', 'fast']
+
+  # User's groups to be configured with the runit service.
+  runit_groups    ['jenkins', 'docker']
 end
 
 # Create a slave with a full environment

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -37,6 +37,9 @@ class Chef
     attribute :service_name,
               kind_of: String,
               default: 'jenkins-slave'
+    attribute :runit_groups,
+              kind_of: Array,
+              default: ['jenkins']
   end
 end
 
@@ -162,6 +165,7 @@ class Chef
           service_name: new_resource.service_name,
           jvm_options: new_resource.jvm_options,
           user: new_resource.user,
+          runit_groups: new_resource.runit_groups,
           remote_fs: new_resource.remote_fs,
           java_bin: java,
           slave_jar: slave_jar,

--- a/templates/sv-jenkins-slave-run.erb
+++ b/templates/sv-jenkins-slave-run.erb
@@ -5,9 +5,10 @@
 # Do NOT modify this file by hand.
 #
 
+<% groups = ([@options[:user]] + @options[:runit_groups]).join(':') %>
 exec 2>&1
 cd <%= @options[:remote_fs] %>
-exec chpst -u <%= @options[:user] %> \
+exec chpst -u <%= groups %> -U <%= groups %> \
   env HOME=<%= @options[:remote_fs] %> \
   JENKINS_HOME=<%= @options[:remote_fs] %> \
   <%= @options[:java_bin] %> \

--- a/test/fixtures/cookbooks/jenkins_slave/recipes/create_jnlp.rb
+++ b/test/fixtures/cookbooks/jenkins_slave/recipes/create_jnlp.rb
@@ -28,7 +28,7 @@ jenkins_jnlp_slave 'jnlp-smoke' do
   labels          %w(runner fast)
   user           'jenkins-smoke'
   group          'jenkins-smoke'
-  runit_groups   %w(jenkins-smoke)
+  runit_groups    %w(jenkins-smoke)
 
   action :create
 end

--- a/test/fixtures/cookbooks/jenkins_slave/recipes/create_jnlp.rb
+++ b/test/fixtures/cookbooks/jenkins_slave/recipes/create_jnlp.rb
@@ -28,6 +28,7 @@ jenkins_jnlp_slave 'jnlp-smoke' do
   labels          %w(runner fast)
   user           'jenkins-smoke'
   group          'jenkins-smoke'
+  runit_groups   %w(jenkins-smoke)
 
   action :create
 end

--- a/test/fixtures/cookbooks/jenkins_slave/recipes/create_jnlp.rb
+++ b/test/fixtures/cookbooks/jenkins_slave/recipes/create_jnlp.rb
@@ -28,7 +28,7 @@ jenkins_jnlp_slave 'jnlp-smoke' do
   labels          %w(runner fast)
   user           'jenkins-smoke'
   group          'jenkins-smoke'
-  runit_groups    %w(jenkins-smoke)
+  runit_groups   %w(jenkins-smoke)
 
   action :create
 end

--- a/test/integration/jenkins_smoke/controls/jenkins_slave.rb
+++ b/test/integration/jenkins_smoke/controls/jenkins_slave.rb
@@ -58,6 +58,7 @@ control 'jenkins_slave-1.0' do
     its('in_demand_delay') { should eq 1 }
     its('idle_delay') { should eq 3 }
     its('labels') { should eq %w(fast runner) }
+    its('runit_groups'} { should eq %w(jenkins-smoke) }
 
     # it might be connected, depending on disconnection timing
     # it { should be_connected }

--- a/test/integration/jenkins_smoke/controls/jenkins_slave.rb
+++ b/test/integration/jenkins_smoke/controls/jenkins_slave.rb
@@ -58,7 +58,6 @@ control 'jenkins_slave-1.0' do
     its('in_demand_delay') { should eq 1 }
     its('idle_delay') { should eq 3 }
     its('labels') { should eq %w(fast runner) }
-    its('runit_groups') { should eq %w(jenkins-smoke) }
 
     # it might be connected, depending on disconnection timing
     # it { should be_connected }

--- a/test/integration/jenkins_smoke/controls/jenkins_slave.rb
+++ b/test/integration/jenkins_smoke/controls/jenkins_slave.rb
@@ -58,7 +58,7 @@ control 'jenkins_slave-1.0' do
     its('in_demand_delay') { should eq 1 }
     its('idle_delay') { should eq 3 }
     its('labels') { should eq %w(fast runner) }
-    its('runit_groups'} { should eq %w(jenkins-smoke) }
+    its('runit_groups') { should eq %w(jenkins-smoke) }
 
     # it might be connected, depending on disconnection timing
     # it { should be_connected }


### PR DESCRIPTION
…jenkins user

* Add attribute 'runit_groups' to jenkins_jnlp_slave resource to configure any of the user's groups defined in this attribute with the runit_service.

Signed-off-by: Jonathan An <jan@esri.com>

### Description

Allows the `jenkins_jnlp_slave` resource to configure the user's groups as part of the `runit_service`. Any groups defined in this new resource attribute `runit_groups` will be configured as long as the user is already part of the group.

This was fixed awhile back for the master resource as part of this issue:
https://github.com/chef-cookbooks/jenkins/issues/205

This is a similar fix for the jnlp slave resource.

### Issues Resolved

https://github.com/chef-cookbooks/jenkins/issues/685

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
