### PR TITLE
Pass booleans unquoted

### DIFF
--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -145,6 +145,7 @@ job must first exist on the Jenkins master!
               command_args << "-p #{key}=#{value}"
             else 
               command_args << "-p #{key}='#{value}'"
+            end
           end
 
           if new_resource.stream_job_output && new_resource.wait_for_completion && stdout_stream

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -140,7 +140,11 @@ job must first exist on the Jenkins master!
           end
 
           new_resource.parameters.each_pair do |key, value|
-            command_args << "-p #{key}='#{value}'"
+            case value
+            when TrueClass, FalseClass
+              command_args << "-p #{key}=#{value}"
+            else 
+              command_args << "-p #{key}='#{value}'"
           end
 
           if new_resource.stream_job_output && new_resource.wait_for_completion && stdout_stream

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -143,7 +143,7 @@ job must first exist on the Jenkins master!
             case value
             when TrueClass, FalseClass
               command_args << "-p #{key}=#{value}"
-            else 
+            else
               command_args << "-p #{key}='#{value}'"
             end
           end


### PR DESCRIPTION
### Description
Currently when passing in parameters the code always quotes them. If they are booleans when quoted Jenkins treats them as text instead of boolean. 
This change skips quotes if the value is of TrueClass or FalseClass.
### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
