### PR TITLE
Fix to provide jenkins_view

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -47,7 +47,7 @@ If this problem persists, check your Jenkins log files.
 
     # Matches Version 4 UUID per RFC 4122
     # Example: 38537014-ec66-49b5-aff2-aed1c19e2989
-    UUID_REGEX = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/ unless defined?(UUID_REGEX)
+    UUID_REGEX = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/.freeze unless defined?(UUID_REGEX)
 
     #
     # Helper method for creating an accessing a new {Jenkins::Executor} from

--- a/libraries/view.rb
+++ b/libraries/view.rb
@@ -69,6 +69,8 @@ view must first exist on the Jenkins master!
 
     include Jenkins::Helper
 
+    provides :jenkins_view
+
     def load_current_resource
       @current_resource ||= Resource::JenkinsView.new(new_resource.name)
       @current_resource.name(new_resource.name)

--- a/spec/libraries/view_spec.rb
+++ b/spec/libraries/view_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe Chef::Provider::JenkinsView do
+  describe 'provides :jenkins_view' do
+    before do
+      allow(described_class).to receive(:new).and_wrap_original do |m, *args|
+        view_double = double('view').tap do |d|
+          allow(d).to receive(:[]).with(:jobs).and_return([])
+        end
+        m.call(*args).tap do |v|
+          allow(v).to receive(:current_view).and_return(view_double)
+          allow(v).to receive(:executor)
+            .and_return(double('executor').as_null_object)
+        end
+      end
+    end
+
+    step_into :jenkins_view
+
+    recipe do
+      jenkins_view 'ham' do
+        jobs %w(pig giraffe)
+      end
+    end
+
+    it 'should not raise Chef::Exceptions::ProviderNotFound' do
+      expect { chef_run }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
### Description

This PR should fix `Chef::Exceptions::ProviderNotFound` error when using `jenkins_view` in recipes.

### Issues Resolved

None.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented in the README if applicable~~
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
