### PR TITLE
Updates to support Debian 9 and supporting JENKINS_ENABLE_ACCESS_LOG

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -192,6 +192,10 @@ default['jenkins']['master'].tap do |master|
   #
   master['log_directory'] = '/var/log/jenkins'
 
+  # Whether to enable web access logging or not.
+  # Set to "yes" to enable logging to /var/log/$NAME/access_log
+  master['access_log'] = 'no'
+
   #
   # Set the max open files to a specific value.
   # Due to http://github.com/jenkinsci/jenkins/commit/2fb288474e980d0e7ff9c4a3b768874835a3e92e

--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -23,7 +23,7 @@
 
 case node['platform_family']
 when 'debian'
-  package 'apt-transport-https'
+  package %w( apt-transport-https fontconfig )
 
   apt_repository 'jenkins' do
     uri          node['jenkins']['master']['repository']

--- a/templates/jenkins-config-debian.erb
+++ b/templates/jenkins-config-debian.erb
@@ -27,13 +27,17 @@ JENKINS_WAR=/usr/share/jenkins/jenkins.war
 # jenkins home location
 JENKINS_HOME=<%= node['jenkins']['master']['home'] %>
 
-# set this to false if you don't want Hudson to run by itself
+# set this to false if you don't want Jenkins to run by itself
 # in this set up, you are expected to provide a servlet container
 # to host jenkins.
 RUN_STANDALONE=true
 
 # log location.  this may be a syslog facility.priority
 JENKINS_LOG=<%= node['jenkins']['master']['log_directory'] %>/$NAME.log
+
+# Whether to enable web access logging or not.
+# Set to "yes" to enable logging to /var/log/$NAME/access_log
+JENKINS_ENABLE_ACCESS_LOG="<%= node['jenkins']['master']['access_log'] %>"
 
 # OS LIMITS SETUP
 #   comment this out to observe /etc/security/limits.conf


### PR DESCRIPTION
Running the master recipe on Debian 9 exposes https://github.com/AdoptOpenJDK/openjdk-build/issues/693
The solution is to add the fontconfig package. While I was debugging, I
cleaned up the Debian template with the JENKINS_ENABLE_ACCESS_LOG exposed
as an attribute to reduce the config template diff.

Signed-off-by: Matt Ray <matthewhray@gmail.com>