### PR TITLE
Set default CLI protocol attribute to http

### DIFF
--- a/attributes/executor.rb
+++ b/attributes/executor.rb
@@ -52,9 +52,9 @@ default['jenkins']['executor'].tap do |executor|
   executor['jvm_options'] = nil
 
   #
-  # CLI protocol [ssh|http|remoting]
+  # CLI protocol [ssh|http]
   #
-  executor['protocol'] = 'remoting'
+  executor['protocol'] = 'http'
 
   #
   # CLI user to pass for ssh/https protocol


### PR DESCRIPTION
### Description
The previously deprecated CLI remoting feature has now been removed from Jenkins in v 2.165. The recommended default protocol is now http.

See: https://jenkins.io/blog/2019/02/17/remoting-cli-removed/

### Issues Resolved

Fixes #722 
