### PR TITLE
Auto accept Chef licenses when running tests

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -14,6 +14,7 @@ provisioner:
   name: chef_zero
   data_path: test/fixtures/keys
   data_bags_path: test/fixtures/data_bags
+  chef_license: accept
   attributes:
     jenkins:
       master:

--- a/test/fixtures/cookbooks/jenkins_server_wrapper/attributes/default.rb
+++ b/test/fixtures/cookbooks/jenkins_server_wrapper/attributes/default.rb
@@ -1,5 +1,4 @@
 # make sure we get the correct version of java installed
-default['java']['install_flavor'] = 'oracle'
+default['java']['install_flavor'] = 'adoptopenjdk'
 default['java']['jdk_version'] = '8'
 default['java']['set_etc_environment'] = true
-default['java']['oracle']['accept_oracle_download_terms'] = true


### PR DESCRIPTION
### Description

Tests are currently failing in CI due to non-acceptance of the Chef software licenses. 
This automatically accepts Chef licenses when running tests as documented here: https://docs.chef.io/chef_license_accept.html
