### PR TITLE
List more available actions than default only

### DIFF
--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -32,6 +32,7 @@ class Chef
 
     # Actions
     default_action :create
+    actions :create, :delete, :connect, :disconnect, :online, :offline
 
     # Attributes
     attribute :slave_name,


### PR DESCRIPTION
FATAL: Chef::Exceptions::ValidationFailed: Option action must be equal to
one of: :nothing, :create!  You passed :connect.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>