### PR TITLE
Adding support for SSH Slaves/SSH Build Agents plugin version >= 1.30

### DIFF
--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -1,4 +1,4 @@
-#
+-#
 # Cookbook:: jenkins
 # Resource:: ssh_slave
 #
@@ -37,7 +37,7 @@ class Chef
               kind_of: Integer,
               default: 22
     attribute :credentials,
-              kind_of: [Resource::JenkinsCredentials, String]
+              kind_of: String
     attribute :command_prefix,
               kind_of: String
     attribute :command_suffix,
@@ -101,19 +101,22 @@ class Chef
     #
     def launcher_groovy
       <<-EOH.gsub(/ ^{8}/, '')
+        import hudson.plugins.sshslaves.verifiers.*
+
         #{credential_lookup_groovy('credentials')}
         launcher =
           new hudson.plugins.sshslaves.SSHLauncher(
             #{convert_to_groovy(new_resource.host)},
             #{convert_to_groovy(new_resource.port)},
-            credentials,
+            #{convert_to_groovy(new_resource.credentials)},
             #{convert_to_groovy(new_resource.jvm_options)},
             #{convert_to_groovy(new_resource.java_path)},
             #{convert_to_groovy(new_resource.command_prefix)},
             #{convert_to_groovy(new_resource.command_suffix)},
             #{convert_to_groovy(new_resource.launch_timeout)},
             #{convert_to_groovy(new_resource.ssh_retries)},
-            #{convert_to_groovy(new_resource.ssh_wait_retries)}
+            #{convert_to_groovy(new_resource.ssh_wait_retries)},
+            new ManuallyTrustedKeyVerificationStrategy(false)
           )
       EOH
     end


### PR DESCRIPTION
### Description
SSH Slaves plugin now requires a `SshHostKeyVerificationStrategy` when the slave is joined to the master.  This also changes the `credentials` parameter to be a Jenkins credentials ID.

### Issues Resolved
https://github.com/chef-cookbooks/jenkins/issues/589
https://github.com/chef-cookbooks/jenkins/issues/726
