### PR TITLE
Added attribute value for directory mode for jenkins directories

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -131,6 +131,11 @@ default['jenkins']['master'].tap do |master|
   master['group'] = 'jenkins'
 
   #
+  # Directory mode for Jenkins directories.
+  #
+  master['mode'] = '0755'
+
+  #
   # Jenkins user/group should be created as `system` accounts for `war` install.
   # The default of `true` will ensure that **new** jenkins user accounts are
   # created in the system ID range, existing users will not be modified.

--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -49,7 +49,7 @@ end
 directory node['jenkins']['master']['home'] do
   owner     node['jenkins']['master']['user']
   group     node['jenkins']['master']['group']
-  mode      '0755'
+  mode      node['jenkins']['master']['mode']
   recursive true
 end
 
@@ -67,7 +67,7 @@ end
     path "/var/#{folder}/jenkins"
     owner node['jenkins']['master']['user']
     group node['jenkins']['master']['group']
-    mode '0755'
+    mode node['jenkins']['master']['mode']
     action :create
   end
 end

--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -40,7 +40,7 @@ end
 directory node['jenkins']['master']['home'] do
   owner     node['jenkins']['master']['user']
   group     node['jenkins']['master']['group']
-  mode      '0755'
+  mode      node['jenkins']['master']['mode']
   recursive true
 end
 


### PR DESCRIPTION
added attribute value Directory mode for Jenkins directories in attribute file master.rb 

### Description
added Directory mode for Jenkins directories as master['mode'] = '0755' 
so whenever user wants he can override his value by passing desired home directory permissions  
