### PR TITLE
Update resources so they can be found by chef 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is used to list changes made in each version of the jenkins cookbook.
 - resolved cookstyle error: libraries/slave_jnlp.rb:64:14 warning: `ChefDeprecations/ChefWindowsPlatformHelper`
 - resolved cookstyle error: libraries/slave_jnlp.rb:91:83 warning: `ChefDeprecations/ChefWindowsPlatformHelper`
 - resolved cookstyle error: libraries/slave_jnlp.rb:95:17 warning: `ChefDeprecations/ChefWindowsPlatformHelper`
+- resolved issue with resources not being found by chef 16
 
 ## 7.1.2 (2020-03-05)
 

--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -23,7 +23,8 @@ require_relative '_helper'
 
 class Chef
   class Resource::JenkinsCommand < Resource::LWRPBase
-    resource_name :jenkins_command
+    resource_name :jenkins_command # Still needed for Chef 15 and below
+    provides :jenkins_command
 
     # Chef attributes
     identity_attr :command

--- a/libraries/credentials_file.rb
+++ b/libraries/credentials_file.rb
@@ -26,6 +26,10 @@ require_relative 'credentials'
 class Chef
   class Resource::JenkinsFileCredentials < Resource::JenkinsCredentials
     include Jenkins::Helper
+
+    resource_name :jenkins_file_credentials # Still needed for Chef 15 and below
+    provides :jenkins_file_credentials
+
     attribute :description,
               kind_of: String,
               default: lazy { |new_resource| "Credentials for #{new_resource.filename} - created by Chef" }

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -24,7 +24,8 @@ require_relative 'credentials_user'
 
 class Chef
   class Resource::JenkinsPasswordCredentials < Resource::JenkinsUserCredentials
-    resource_name :jenkins_password_credentials
+    resource_name :jenkins_password_credentials # Still needed for Chef 15 and below
+    provides :jenkins_password_credentials
 
     # Attributes
     attribute :username,

--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -37,7 +37,8 @@ class Chef
   class Resource::JenkinsPrivateKeyCredentials < Resource::JenkinsUserCredentials
     include Jenkins::Helper
 
-    resource_name :jenkins_private_key_credentials
+    resource_name :jenkins_private_key_credentials # Still needed for Chef 15 and below
+    provides :jenkins_private_key_credentials
 
     # Attributes
     attribute :username,

--- a/libraries/credentials_secret_text.rb
+++ b/libraries/credentials_secret_text.rb
@@ -23,7 +23,8 @@ require_relative 'credentials'
 
 class Chef
   class Resource::JenkinsSecretTextCredentials < Resource::JenkinsCredentials
-    resource_name :jenkins_secret_text_credentials
+    resource_name :jenkins_secret_text_credentials # Still needed for Chef 15 and below
+    provides :jenkins_secret_text_credentials
 
     # Chef attributes
     identity_attr :description

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -25,7 +25,8 @@ require_relative '_helper'
 
 class Chef
   class Resource::JenkinsJob < Resource::LWRPBase
-    resource_name :jenkins_job
+    resource_name :jenkins_job # Still needed for Chef 15 and below
+    provides :jenkins_job
 
     # Chef attributes
     identity_attr :name

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -26,7 +26,8 @@ require_relative '_helper'
 
 class Chef
   class Resource::JenkinsPlugin < Resource::LWRPBase
-    resource_name :jenkins_plugin
+    resource_name :jenkins_plugin # Still needed for Chef 15 and below
+    provides :jenkins_plugin
 
     # Chef attributes
     identity_attr :name

--- a/libraries/proxy.rb
+++ b/libraries/proxy.rb
@@ -26,7 +26,8 @@ require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsProxy < Resource::LWRPBase
-    resource_name :jenkins_proxy
+    resource_name :jenkins_proxy # Still needed for Chef 15 and below
+    provides :jenkins_proxy
 
     # Chef attributes
     identity_attr :proxy

--- a/libraries/script.rb
+++ b/libraries/script.rb
@@ -23,7 +23,8 @@ require_relative 'command'
 
 class Chef
   class Resource::JenkinsScript < Resource::JenkinsCommand
-    resource_name :jenkins_script
+    resource_name :jenkins_script # Still needed for Chef 15 and below
+    provides :jenkins_script
 
     # Chef attributes
     identity_attr :name

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -25,7 +25,8 @@ require_relative '_helper'
 
 class Chef
   class Resource::JenkinsSlave < Resource::LWRPBase
-    resource_name :jenkins_slave
+    resource_name :jenkins_slave # Still needed for Chef 15 and below
+    provides :jenkins_slave
 
     # Chef attributes
     identity_attr :slave_name

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -23,7 +23,8 @@ require_relative 'slave'
 
 class Chef
   class Resource::JenkinsJnlpSlave < Resource::JenkinsSlave
-    resource_name :jenkins_jnlp_slave
+    resource_name :jenkins_jnlp_slave # Still needed for Chef 15 and below
+    provides :jenkins_jnlp_slave
 
     # Actions
     actions :create, :delete, :connect, :disconnect, :online, :offline

--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -24,7 +24,8 @@ require_relative 'credentials'
 
 class Chef
   class Resource::JenkinsSshSlave < Resource::JenkinsSlave
-    resource_name :jenkins_ssh_slave
+    resource_name :jenkins_ssh_slave # Still needed for Chef 15 and below
+    provides :jenkins_ssh_slave
 
     # Actions
     actions :create, :delete, :connect, :disconnect, :online, :offline

--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -24,7 +24,8 @@ require_relative 'slave_jnlp'
 
 class Chef
   class Resource::JenkinsWindowsSlave < Resource::JenkinsJnlpSlave
-    resource_name :jenkins_windows_slave
+    resource_name :jenkins_windows_slave # Still needed for Chef 15 and below
+    provides :jenkins_windows_slave
 
     # Actions
     actions :create, :delete, :connect, :disconnect, :online, :offline

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -25,7 +25,8 @@ require_relative '_helper'
 
 class Chef
   class Resource::JenkinsUser < Resource::LWRPBase
-    resource_name :jenkins_user
+    resource_name :jenkins_user # Still needed for Chef 15 and below
+    provides :jenkins_user
 
     # Chef attributes
     identity_attr :id

--- a/libraries/view.rb
+++ b/libraries/view.rb
@@ -22,7 +22,8 @@ require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsView < Resource::LWRPBase
-    resource_name :jenkins_view
+    resource_name :jenkins_view # Still needed for Chef 15 and below
+    provides :jenkins_view
 
     # Chef attributes
     identity_attr :name


### PR DESCRIPTION
### Description
Included the provides line to each of the resources that had the resource_name so that chef 16 will find them

### Issues Resolved
I did not find one. I can make one if its needed

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>