### PR TITLE
Remove .NET 2.0

### DIFF
--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -160,7 +160,6 @@ class Chef
         <<-EOH.gsub(/^ {8}/, '')
         <configuration>
           <startup>
-            <supportedRuntime version="v2.0.50727" />
             <supportedRuntime version="v4.0" />
           </startup>
         </configuration>


### PR DESCRIPTION
Signed-off-by: Mendy Baitelman <mendy@baitelman.com>


### Description
Removes .NET 2.0

### Issues Resolved
Fixes #751 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>