### PR TITLE
Dont quote param unnecessarily 

### DIFF
--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -132,8 +132,10 @@ job must first exist on the Jenkins master!
             case value
             when TrueClass, FalseClass
               command_args << "-p #{key}=#{value}"
-            else
+            when value.include?(' ')
               command_args << "-p #{key}='#{value}'"
+            else
+              command_args << "-p #{key}=#{value}"
             end
           end
 

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -132,10 +132,12 @@ job must first exist on the Jenkins master!
             case value
             when TrueClass, FalseClass
               command_args << "-p #{key}=#{value}"
-            when value.include?(' ')
-              command_args << "-p #{key}='#{value}'"
             else
-              command_args << "-p #{key}=#{value}"
+              command_args << if value.include?(' ')
+                                "-p #{key}='#{value}'"
+                              else
+                                "-p #{key}=#{value}"
+                              end
             end
           end
 


### PR DESCRIPTION
Only quote parameter values that include a space. 

### Description
When running a Jenkins job that includes a [choice parameter](https://www.jenkins.io/doc/book/pipeline/syntax/#parameters) it can not be quoted or else it doesn't match the allowed list of choices.
```       
---- Begin output of "java" -jar "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\cache/jenkins-cli.jar" -s http://jenkins.corp.com:8080 -"http" -auth "chef":"PASS" build JobName -s -p NODE='test1374' -p BRANCH='master' -p ACCOUNT='qa' -p FORCE_NPM=true -v ----
       STDOUT:
       STDERR: ERROR: Illegal choice for parameter ACCOUNT: 'qa'
```
### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>